### PR TITLE
Call WSAStartup on Windows

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -44,6 +44,15 @@ static timestamp_t current_timestamp() {
 
 juice_agent_t *agent_create(const juice_config_t *config) {
 	JLOG_VERBOSE("Creating agent");
+
+#ifdef _WIN32
+	WSADATA wsaData;
+	if (WSAStartup(MAKEWORD(2, 2), &wsaData)) {
+		JLOG_FATAL("WSAStartup failed");
+		return NULL;
+	}
+#endif
+
 	juice_agent_t *agent = malloc(sizeof(juice_agent_t));
 	if (!agent) {
 		JLOG_FATAL("malloc for agent failed");
@@ -80,6 +89,10 @@ void agent_do_destroy(juice_agent_t *agent) {
 	close(agent->sock);
 	pthread_mutex_destroy(&agent->mutex);
 	free(agent);
+
+#ifdef _WIN32
+	WSACleanup();
+#endif
 }
 
 void agent_destroy(juice_agent_t *agent) {

--- a/test/main.c
+++ b/test/main.c
@@ -45,14 +45,6 @@ void on_recv2(juice_agent_t *agent, const char *data, size_t size, void *user_pt
 int preliminary_tests(void);
 
 int main(int argc, char **argv) {
-#ifdef _WIN32
-	WSADATA wsaData;
-	if (WSAStartup(MAKEWORD(2, 2), &wsaData)) {
-		fprintf(stderr, "WSAStartup failed");
-		return -1;
-	}
-#endif
-
 	int ret = preliminary_tests();
 	if (ret != 0)
 		return ret;
@@ -119,10 +111,6 @@ int main(int argc, char **argv) {
 	juice_destroy(agent1);
 	juice_destroy(agent2);
 	sleep(2);
-
-#ifdef _WIN32
-	WSACleanup();
-#endif
 
 	if (success) {
 		printf("Success\n");


### PR DESCRIPTION
For Windows, call WSAStartup in agent instead of expecting it to be called from outside.