### PR TITLE
Rename ioctl and close

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -86,7 +86,7 @@ juice_agent_t *agent_create(const juice_config_t *config) {
 
 void agent_do_destroy(juice_agent_t *agent) {
 	JLOG_VERBOSE("Destroying agent");
-	close(agent->sock);
+	closesocket(agent->sock);
 	pthread_mutex_destroy(&agent->mutex);
 	free(agent);
 

--- a/src/socket.h
+++ b/src/socket.h
@@ -48,8 +48,6 @@
 typedef SOCKET socket_t;
 typedef SOCKADDR sockaddr;
 typedef u_long ctl_t;
-#define close closesocket
-#define ioctl ioctlsocket
 #define sockerrno ((int)WSAGetLastError())
 #define IP_DONTFRAG IP_DONTFRAGMENT
 #define SOCKET_TO_INT(x) 0
@@ -88,6 +86,8 @@ typedef int ctl_t;
 #define sockerrno errno
 #define INVALID_SOCKET -1
 #define SOCKET_TO_INT(x) (x)
+#define ioctlsocket ioctl
+#define closesocket close
 
 #endif // _WIN32
 

--- a/src/udp.c
+++ b/src/udp.c
@@ -84,7 +84,7 @@ socket_t udp_create_socket(void) {
 	}
 
 	ctl_t b = 1;
-	if (ioctl(sock, FIONBIO, &b)) {
+	if (ioctlsocket(sock, FIONBIO, &b)) {
 		JLOG_ERROR("Setting non-blocking mode for UDP socket failed, errno=%d", sockerrno);
 		goto error;
 	}
@@ -247,7 +247,7 @@ int udp_get_addrs(socket_t sock, addr_record_t *records, size_t count) {
 	ifc.ifc_len = sizeof(buf);
 	ifc.ifc_buf = buf;
 
-	if (ioctl(sock, SIOCGIFCONF, &ifc)) {
+	if (ioctlsocket(sock, SIOCGIFCONF, &ifc)) {
 		JLOG_ERROR("ioctl for SIOCGIFCONF failed, errno=%d", sockerrno);
 		return -1;
 	}


### PR DESCRIPTION
This PR renames `ioctl()` and `close()` to prevent potential name collisions with defines.