### PR TITLE
UDP port range in config

### DIFF
--- a/include/juice/juice.h
+++ b/include/juice/juice.h
@@ -51,6 +51,8 @@ typedef void (*juice_cb_recv_t)(juice_agent_t *agent, const char *data, size_t s
 typedef struct juice_config {
 	const char *stun_server_host;
 	unsigned int stun_server_port;
+	unsigned int local_port_range_begin;
+	unsigned int local_port_range_end;
 	juice_cb_state_changed_t cb_state_changed;
 	juice_cb_candidate_t cb_candidate;
 	juice_cb_gathering_done_t cb_gathering_done;

--- a/src/agent.c
+++ b/src/agent.c
@@ -124,7 +124,13 @@ int agent_gather_candidates(juice_agent_t *agent) {
 		pthread_mutex_unlock(&agent->mutex);
 		return 0;
 	}
-	agent->sock = udp_create_socket();
+
+	udp_socket_config_t socket_config;
+	unsigned int port_begin = agent->config.local_port_range_begin;
+	unsigned int port_end = agent->config.local_port_range_end;
+	socket_config.port_begin = (uint16_t)(port_begin <= 0xFFFF ? port_begin : 0xFFFF);
+	socket_config.port_end = (uint16_t)(port_end <= 0xFFFF ? port_end : 0xFFFF);
+	agent->sock = udp_create_socket(&socket_config);
 	if (agent->sock == INVALID_SOCKET) {
 		JLOG_FATAL("UDP socket creation for agent failed");
 		pthread_mutex_unlock(&agent->mutex);

--- a/src/socket.h
+++ b/src/socket.h
@@ -53,6 +53,9 @@ typedef u_long ctl_t;
 #define SOCKET_TO_INT(x) 0
 #define HOST_NAME_MAX 256
 
+#undef EADDRINUSE
+#define EADDRINUSE WSAEADDRINUSE
+
 #else // assume POSIX
 
 #include <arpa/inet.h>

--- a/src/udp.c
+++ b/src/udp.c
@@ -125,7 +125,7 @@ socket_t udp_create_socket(const udp_socket_config_t *config) {
 				freeaddrinfo(ai_list);
 				return sock;
 			}
-		} while (errno == EADDRINUSE && retries-- > 0);
+		} while (sockerrno == EADDRINUSE && retries-- > 0);
 
 		JLOG_ERROR("UDP socket binding failed on port range [%hu, %hu], errno=%d",
 		           config->port_begin, config->port_end, sockerrno);

--- a/src/udp.c
+++ b/src/udp.c
@@ -19,7 +19,9 @@
 #include "udp.h"
 #include "addr.h"
 #include "log.h"
+#include "random.h"
 
+#include <pthread.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -30,7 +32,24 @@ static struct addrinfo *find_family(struct addrinfo *ai_list, unsigned int famil
 	return ai;
 }
 
-socket_t udp_create_socket(void) {
+static uint16_t get_next_port_in_range(uint16_t begin, uint16_t end) {
+	static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+	static uint32_t count = 0;
+	if (begin == 0)
+		begin = 1024;
+	if (end == 0)
+		end = 0xFFFF;
+	if (count == 0)
+		count = juice_rand32();
+
+	pthread_mutex_lock(&mutex);
+	uint32_t diff = end > begin ? end - begin : 0;
+	uint16_t next = begin + count++ % (diff + 1);
+	pthread_mutex_unlock(&mutex);
+	return next;
+}
+
+socket_t udp_create_socket(const udp_socket_config_t *config) {
 	// Obtain local Address
 	struct addrinfo *ai_list = NULL;
 	struct addrinfo hints;
@@ -77,20 +96,40 @@ socket_t udp_create_socket(void) {
 #endif
 #endif
 
-	// Bind it
-	if (bind(sock, ai->ai_addr, ai->ai_addrlen)) {
-		JLOG_ERROR("bind for UDP socket failed, errno=%d", sockerrno);
-		goto error;
-	}
-
 	ctl_t b = 1;
 	if (ioctlsocket(sock, FIONBIO, &b)) {
-		JLOG_ERROR("Setting non-blocking mode for UDP socket failed, errno=%d", sockerrno);
+		JLOG_ERROR("setting non-blocking mode on UDP socket failed, errno=%d", sockerrno);
 		goto error;
 	}
 
-	freeaddrinfo(ai_list);
-	return sock;
+	// Bind it
+	if (config->port_begin == 0 && config->port_end == 0) {
+		if (bind(sock, ai->ai_addr, ai->ai_addrlen) == 0) {
+			freeaddrinfo(ai_list);
+			return sock;
+		}
+
+		JLOG_ERROR("UDP socket binding failed, errno=%d", sockerrno);
+
+	} else {
+		struct sockaddr_storage addr;
+		socklen_t addrlen = ai->ai_addrlen;
+		memcpy(&addr, ai->ai_addr, addrlen);
+
+		int retries = config->port_end - config->port_begin;
+		do {
+			uint16_t port = get_next_port_in_range(config->port_begin, config->port_end);
+			addr_set_port((struct sockaddr *)&addr, port);
+			if (bind(sock, (struct sockaddr *)&addr, addrlen) == 0) {
+				JLOG_DEBUG("UDP socket bound to port %hu", port);
+				freeaddrinfo(ai_list);
+				return sock;
+			}
+		} while (errno == EADDRINUSE && retries-- > 0);
+
+		JLOG_ERROR("UDP socket binding failed on port range [%hu, %hu], errno=%d",
+		           config->port_begin, config->port_end, sockerrno);
+	}
 
 error:
 	freeaddrinfo(ai_list);

--- a/src/udp.h
+++ b/src/udp.h
@@ -22,7 +22,14 @@
 #include "addr.h"
 #include "socket.h"
 
-socket_t udp_create_socket(void);
+#include <stdint.h>
+
+typedef struct udp_socket_config {
+	uint16_t port_begin;
+	uint16_t port_end;
+} udp_socket_config_t;
+
+socket_t udp_create_socket(const udp_socket_config_t *config);
 uint16_t udp_get_port(socket_t sock);
 int udp_get_addrs(socket_t sock, addr_record_t *records, size_t count);
 

--- a/test/connectivity.c
+++ b/test/connectivity.c
@@ -67,6 +67,9 @@ int test_connectivity() {
 	config2.cb_gathering_done = on_gathering_done2;
 	config2.cb_recv = on_recv2;
 	config2.user_ptr = NULL;
+	// Port range example
+	config2.local_port_range_begin = 5000;
+	config2.local_port_range_end = 6000;
 
 	agent2 = juice_create(&config2);
 


### PR DESCRIPTION
Implements https://github.com/paullouisageneau/libjuice/issues/12

Add support for UDP port range constraint in config via fields `local_port_range_begin` and `local_port_range_end` (values `0` mean disabled).

