### PR TITLE
Wait for remote description to unfreeze candidate pairs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ set(TESTS_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/test/crc32.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test/stun.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test/connectivity.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/notrickle.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test/server.c
 )
 

--- a/src/agent.c
+++ b/src/agent.c
@@ -1172,6 +1172,7 @@ void agent_update_gathering_done(juice_agent_t *agent) {
 	}
 	if (!agent->gathering_done) {
 		JLOG_INFO("Candidate gathering done");
+		agent->local.finished = true;
 		agent->gathering_done = true;
 
 		if (agent->config.cb_gathering_done)

--- a/src/agent.c
+++ b/src/agent.c
@@ -1110,7 +1110,7 @@ int agent_unfreeze_candidate_pair(juice_agent_t *agent, ice_candidate_pair_t *pa
 		return 0;
 
 	if (agent->entries_count == MAX_STUN_ENTRIES_COUNT) {
-		JLOG_VERBOSE("No free STUN entry left for candidate pair checking");
+		JLOG_WARN("No free STUN entry left for candidate pair checking");
 		return -1;
 	}
 

--- a/src/agent.h
+++ b/src/agent.h
@@ -80,7 +80,7 @@ typedef struct agent_stun_entry {
 	int retransmissions;
 	bool finished;
 #ifdef NO_ATOMICS
-	bool armed;
+	volatile bool armed;
 #else
 	atomic_flag armed;
 #endif
@@ -103,7 +103,7 @@ struct juice_agent {
 	agent_stun_entry_t entries[MAX_STUN_ENTRIES_COUNT];
 	size_t entries_count;
 #ifdef NO_ATOMICS
-	agent_stun_entry_t *selected_entry;
+	volatile agent_stun_entry_t *selected_entry;
 #else
 	_Atomic(agent_stun_entry_t *) selected_entry;
 #endif

--- a/src/agent.h
+++ b/src/agent.h
@@ -145,6 +145,7 @@ int agent_add_local_reflexive_candidate(juice_agent_t *agent, ice_candidate_type
 int agent_add_remote_reflexive_candidate(juice_agent_t *agent, ice_candidate_type_t type,
                                          uint32_t priority, const addr_record_t *record);
 int agent_add_candidate_pair(juice_agent_t *agent, ice_candidate_t *remote);
+int agent_unfreeze_candidate_pair(juice_agent_t *agent, ice_candidate_pair_t *pair);
 
 void agent_arm_transmission(juice_agent_t *agent, agent_stun_entry_t *entry, timediff_t delay);
 void agent_update_gathering_done(juice_agent_t *agent);

--- a/src/ice.c
+++ b/src/ice.c
@@ -293,8 +293,12 @@ int ice_generate_sdp(const ice_description_t *description, char *buffer, size_t 
 			ret = snprintf(begin, end - begin, "a=ice-ufrag:%s\r\na=ice-pwd:%s\r\n",
 			               description->ice_ufrag, description->ice_pwd);
 		} else if (i < description->candidates_count + 1) {
+			const ice_candidate_t *candidate = description->candidates + i - 1;
+			if (candidate->type == ICE_CANDIDATE_TYPE_UNKNOWN ||
+			    candidate->type == ICE_CANDIDATE_TYPE_PEER_REFLEXIVE)
+				continue;
 			char tmp[BUFFER_SIZE];
-			if (ice_generate_candidate_sdp(description->candidates + i - 1, tmp, BUFFER_SIZE) < 0)
+			if (ice_generate_candidate_sdp(candidate, tmp, BUFFER_SIZE) < 0)
 				continue;
 			ret = snprintf(begin, end - begin, "%s\r\n", tmp);
 		} else { // i == description->candidates_count + 1

--- a/test/connectivity.c
+++ b/test/connectivity.c
@@ -53,8 +53,8 @@ int test_connectivity() {
 	// Agent 1: Create agent
 	juice_config_t config1;
 	memset(&config1, 0, sizeof(config1));
-	// config1.stun_server_host = "stun.l.google.com";
-	// config1.stun_server_port = 19302;
+	config1.stun_server_host = "stun.l.google.com";
+	config1.stun_server_port = 19302;
 	config1.cb_state_changed = on_state_changed1;
 	config1.cb_candidate = on_candidate1;
 	config1.cb_gathering_done = on_gathering_done1;
@@ -66,8 +66,8 @@ int test_connectivity() {
 	// Agent 2: Create agent
 	juice_config_t config2;
 	memset(&config2, 0, sizeof(config2));
-	// config2.stun_server_host = "stun.l.google.com";
-	// config2.stun_server_port = 19302;
+	config2.stun_server_host = "stun.l.google.com";
+	config2.stun_server_port = 19302;
 	config2.cb_state_changed = on_state_changed2;
 	config2.cb_candidate = on_candidate2;
 	config2.cb_gathering_done = on_gathering_done2;

--- a/test/main.c
+++ b/test/main.c
@@ -47,7 +47,6 @@ int main(int argc, char **argv) {
 		return -1;
 	}
 
-#ifndef _MSC_VER // TODO: fix CI
 	printf("\nRunning connectivity test...\n");
 	if (test_connectivity()) {
 		fprintf(stderr, "Connectivity test failed\n");
@@ -59,8 +58,6 @@ int main(int argc, char **argv) {
 		fprintf(stderr, "Non-trickled connectivity test failed\n");
 		return -1;
 	}
-
-#endif
 
 	return 0;
 }

--- a/test/main.c
+++ b/test/main.c
@@ -23,6 +23,7 @@
 int test_crc32(void);
 int test_stun(void);
 int test_connectivity(void);
+int test_notrickle(void);
 int test_server(void);
 
 int main(int argc, char **argv) {
@@ -52,6 +53,13 @@ int main(int argc, char **argv) {
 		fprintf(stderr, "Connectivity test failed\n");
 		return -1;
 	}
+
+	printf("\nRunning non-trickled connectivity test...\n");
+	if (test_notrickle()) {
+		fprintf(stderr, "Non-trickled connectivity test failed\n");
+		return -1;
+	}
+
 #endif
 
 	return 0;

--- a/test/notrickle.c
+++ b/test/notrickle.c
@@ -50,8 +50,8 @@ int test_notrickle() {
 	// Agent 1: Create agent
 	juice_config_t config1;
 	memset(&config1, 0, sizeof(config1));
-	// config1.stun_server_host = "stun.l.google.com";
-	// config1.stun_server_port = 19302;
+	config1.stun_server_host = "stun.l.google.com";
+	config1.stun_server_port = 19302;
 	config1.cb_state_changed = on_state_changed1;
 	config1.cb_gathering_done = on_gathering_done1;
 	config1.cb_recv = on_recv1;
@@ -62,8 +62,8 @@ int test_notrickle() {
 	// Agent 2: Create agent
 	juice_config_t config2;
 	memset(&config2, 0, sizeof(config2));
-	// config2.stun_server_host = "stun.l.google.com";
-	// config2.stun_server_port = 19302;
+	config2.stun_server_host = "stun.l.google.com";
+	config2.stun_server_port = 19302;
 	config2.cb_state_changed = on_state_changed2;
 	config2.cb_gathering_done = on_gathering_done2;
 	config2.cb_recv = on_recv2;


### PR DESCRIPTION
- Prevent useless STUN probing before remote description
- Add non-trickled connectivity test
- Add logging on send error