### PR TITLE
Use BCryptGenRandom instead of CryptGenRandom on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,8 +71,12 @@ target_include_directories(juice-static PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_link_libraries(juice-static PUBLIC Threads::Threads)
 
 if(WIN32)
-	target_link_libraries(juice PRIVATE wsock32 ws2_32) # winsock2
-	target_link_libraries(juice-static PRIVATE wsock32 ws2_32) # winsock2
+	target_link_libraries(juice PRIVATE
+		wsock32 ws2_32 # winsock2
+		bcrypt)
+	target_link_libraries(juice-static PRIVATE
+		wsock32 ws2_32 # winsock2
+		bcrypt)
 endif()
 
 if (USE_NETTLE)

--- a/src/random.c
+++ b/src/random.c
@@ -42,23 +42,19 @@ static int random_bytes(void *buf, size_t size) {
 }
 
 #elif defined(_WIN32)
+
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0601 // Windows 7
+#endif
+
 #include <windows.h>
 //
-#include <wincrypt.h>
+#include <bcrypt.h>
 
 static int random_bytes(void *buf, size_t size) {
-	HCRYPTPROV prov;
-	if (!CryptAcquireContext(&prov, NULL, NULL, PROV_RSA_FULL,
-	                         CRYPT_VERIFYCONTEXT | CRYPT_SILENT)) {
-		JLOG_WARN("Win32: CryptAcquireContext failed");
-		return -1;
-	}
-	BOOL success = CryptGenRandom(prov, (DWORD)size, (BYTE *)buf);
-	if (!success) {
-		JLOG_WARN("Win32: CryptGenRandom failed");
-	}
-	CryptReleaseContext(prov, 0);
-	return success ? 0 : -1;
+	// Requires Windows 7 or later
+	NTSTATUS status = BCryptGenRandom(NULL, (PUCHAR)buf, (ULONG)size, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+	return !status ? 0 : -1;
 }
 
 #else

--- a/src/socket.h
+++ b/src/socket.h
@@ -22,7 +22,7 @@
 #ifdef _WIN32
 
 #ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x0601
+#define _WIN32_WINNT 0x0601 // Windows 7
 #endif
 #ifndef __MSVCRT_VERSION__
 #define __MSVCRT_VERSION__ 0x0601

--- a/src/thread.h
+++ b/src/thread.h
@@ -22,7 +22,7 @@
 #ifdef _WIN32
 
 #ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x0601
+#define _WIN32_WINNT 0x0601 // Windows 7
 #endif
 #ifndef __MSVCRT_VERSION__
 #define __MSVCRT_VERSION__ 0x0601


### PR DESCRIPTION
This drops support for Windows XP and Windows Vista.

Fixes https://github.com/paullouisageneau/libjuice/issues/44