### PR TITLE
Add candidates pair getter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,11 @@ if(WIN32)
 	target_link_libraries(juice-static PRIVATE wsock32 ws2_32) # winsock2
 endif()
 
+if(APPLE)
+	# This is necessary for connections to the local machine to succeed on macOS
+	target_compile_definitions(juice PRIVATE JUICE_ENABLE_LOCAL_ADDRESS_TRANSLATION=1)
+endif()
+
 if (USE_NETTLE)
 	find_package(Nettle REQUIRED)
     target_compile_definitions(juice PRIVATE USE_NETTLE=1)

--- a/include/juice/juice.h
+++ b/include/juice/juice.h
@@ -36,6 +36,7 @@ extern "C" {
 // ICE Agent
 
 #define JUICE_MAX_ADDRESS_STRING_LEN 56
+#define JUICE_MAX_CANDIDATE_SDP_STRING_LEN 256
 #define JUICE_MAX_SDP_STRING_LEN 4096
 
 typedef struct juice_agent juice_agent_t;
@@ -77,6 +78,8 @@ JUICE_EXPORT int juice_add_remote_candidate(juice_agent_t *agent, const char *sd
 JUICE_EXPORT int juice_set_remote_gathering_done(juice_agent_t *agent);
 JUICE_EXPORT int juice_send(juice_agent_t *agent, const char *data, size_t size);
 JUICE_EXPORT juice_state_t juice_get_state(juice_agent_t *agent);
+JUICE_EXPORT int juice_get_selected_candidates(juice_agent_t *agent, char *local, size_t local_size,
+                                               char *remote, size_t remote_size);
 JUICE_EXPORT int juice_get_selected_addresses(juice_agent_t *agent, char *local, size_t local_size,
                                               char *remote, size_t remote_size);
 

--- a/src/agent.c
+++ b/src/agent.c
@@ -932,8 +932,10 @@ int agent_process_stun_binding(juice_agent_t *agent, const stun_message_t *msg,
 		JLOG_DEBUG("Received STUN binding success response from %s",
 		           entry->type == AGENT_STUN_ENTRY_TYPE_CHECK ? "client" : "server");
 
-		entry->state = AGENT_STUN_ENTRY_STATE_SUCCEEDED;
-		entry->next_transmission = 0;
+		if(entry->state != AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE) {
+			entry->state = AGENT_STUN_ENTRY_STATE_SUCCEEDED;
+			entry->next_transmission = 0;
+		}
 
 		if (!agent->selected_pair || !agent->selected_pair->nominated) {
 			// We want to send keepalives now

--- a/src/agent.c
+++ b/src/agent.c
@@ -1403,7 +1403,7 @@ void agent_translate_host_candidate_entry(juice_agent_t *agent, agent_stun_entry
 	if (!entry->pair || entry->pair->remote->type != ICE_CANDIDATE_TYPE_HOST)
 		return;
 
-#ifndef JUICE_DISABLE_LOCAL_ADDRESS_TRANSLATION
+#if JUICE_ENABLE_LOCAL_ADDRESS_TRANSLATION
 	for (int i = 0; i < agent->local.candidates_count; ++i) {
 		ice_candidate_t *candidate = agent->local.candidates + i;
 		if (candidate->type != ICE_CANDIDATE_TYPE_HOST)

--- a/src/agent.c
+++ b/src/agent.c
@@ -552,7 +552,7 @@ int agent_bookkeeping(juice_agent_t *agent, timestamp_t *next_timestamp) {
 			if (entry->next_transmission > now)
 				continue;
 
-			if (entry->next_transmission && entry->retransmissions >= 0) {
+			if (entry->retransmissions >= 0) {
 				JLOG_DEBUG("STUN entry %d: Sending request (%d retransmissions left)",
 				           entry->retransmissions);
 
@@ -689,7 +689,7 @@ int agent_bookkeeping(juice_agent_t *agent, timestamp_t *next_timestamp) {
 				if (entry->pair && entry->pair == nominated_pair) {
 					if(entry->state != AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE) {
 						entry->state = AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE;
-						agent_arm_transmission(agent, entry, 0); // transmit now
+						agent_arm_transmission(agent, entry, STUN_KEEPALIVE_PERIOD);
 					}
 				}
 				else {

--- a/src/agent.c
+++ b/src/agent.c
@@ -549,11 +549,13 @@ int agent_bookkeeping(juice_agent_t *agent, timestamp_t *next_timestamp) {
 
 		// STUN requests transmission or retransmission
 		if (entry->state == AGENT_STUN_ENTRY_STATE_PENDING) {
-			if (!entry->next_transmission || entry->next_transmission > now)
+			if (entry->next_transmission > now)
 				continue;
 
-			if (entry->retransmissions >= 0) {
-				JLOG_DEBUG("STUN entry %d: Sending request", i);
+			if (entry->next_transmission && entry->retransmissions >= 0) {
+				JLOG_DEBUG("STUN entry %d: Sending request (%d retransmissions left)",
+				           entry->retransmissions);
+
 				if (agent_send_stun_binding(agent, entry, STUN_CLASS_REQUEST, 0, NULL, NULL) >= 0) {
 					--entry->retransmissions;
 					entry->next_transmission = now + entry->retransmission_timeout;
@@ -571,7 +573,6 @@ int agent_bookkeeping(juice_agent_t *agent, timestamp_t *next_timestamp) {
 
 			if (entry->type == AGENT_STUN_ENTRY_TYPE_SERVER)
 				agent_update_gathering_done(agent);
-
 		}
 		// STUN keepalives
 		// RFC 8445 11. Keepalives: All endpoints MUST send keepalives for each data session.
@@ -586,7 +587,7 @@ int agent_bookkeeping(juice_agent_t *agent, timestamp_t *next_timestamp) {
 				agent_arm_transmission(agent, entry, STUN_KEEPALIVE_PERIOD);
 			}
 
-			if (!entry->next_transmission || entry->next_transmission > now)
+			if (entry->next_transmission > now)
 				continue;
 
 			JLOG_DEBUG("STUN entry %d: Sending keepalive", i);
@@ -620,7 +621,7 @@ int agent_bookkeeping(juice_agent_t *agent, timestamp_t *next_timestamp) {
 			if (!selected_pair)
 				selected_pair = pair;
 		} else if (pair->state == ICE_CANDIDATE_PAIR_STATE_PENDING) {
-			if (nominated_pair || (selected_pair && agent->mode == AGENT_MODE_CONTROLLING)) {
+			if (agent->mode == AGENT_MODE_CONTROLLING && selected_pair) {
 				// A higher-priority pair will be used, we can stop checking
 				// Entries will be synchronized after the current loop
 				JLOG_VERBOSE("Cancelling check for lower-priority pair");
@@ -652,21 +653,23 @@ int agent_bookkeeping(juice_agent_t *agent, timestamp_t *next_timestamp) {
 
 			for (int i = 0; i < agent->entries_count; ++i) {
 				agent_stun_entry_t *entry = agent->entries + i;
-				if (!entry->pair)
-					continue;
-
 				if (entry->pair == selected_pair) {
 #ifdef NO_ATOMICS
 					agent->selected_entry = entry;
 #else
 					atomic_store(&agent->selected_entry, entry);
 #endif
-				} else if (agent->mode == AGENT_MODE_CONTROLLING &&
-				           entry->pair->state == ICE_CANDIDATE_PAIR_STATE_PENDING) {
-					// Limit retransmissions of still pending ones
-					if (entry->retransmissions > 1)
-						entry->retransmissions = 1;
+					break;
 				}
+			}
+		}
+
+		if(selected_pair->nominated || agent->mode == AGENT_MODE_CONTROLLING) {
+			// Limit retransmissions of still pending entries
+			for (int i = 0; i < agent->entries_count; ++i) {
+				agent_stun_entry_t *entry = agent->entries + i;
+				if (entry->state == AGENT_STUN_ENTRY_STATE_PENDING && entry->retransmissions > 1)
+					entry->retransmissions = 1;
 			}
 		}
 
@@ -683,10 +686,16 @@ int agent_bookkeeping(juice_agent_t *agent, timestamp_t *next_timestamp) {
 			// Enable keepalive only for the entry of the nominated pair
 			for (int i = 0; i < agent->entries_count; ++i) {
 				agent_stun_entry_t *entry = agent->entries + i;
-				if (entry->pair && entry->pair == nominated_pair)
-					entry->state = AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE;
-				else if (entry->state == AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE)
-					entry->state = AGENT_STUN_ENTRY_STATE_SUCCEEDED;
+				if (entry->pair && entry->pair == nominated_pair) {
+					if(entry->state != AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE) {
+						entry->state = AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE;
+						agent_arm_transmission(agent, entry, 0); // transmit now
+					}
+				}
+				else {
+					if (entry->state == AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE)
+						entry->state = AGENT_STUN_ENTRY_STATE_SUCCEEDED;
+				}
 			}
 		} else {
 			// Connected
@@ -858,7 +867,7 @@ int agent_process_stun_binding(juice_agent_t *agent, const stun_message_t *msg,
 		//  ERROR-CODE attribute with a value of 487 (Role Conflict) but retains its role.
 		//  * If the agent's tiebreaker value is less than the contents of the ICE-CONTROLLING
 		//  attribute, the agent switches to the controlled role.
-		if (msg->ice_controlling && agent->mode == AGENT_MODE_CONTROLLING) {
+		if (agent->mode == AGENT_MODE_CONTROLLING && msg->ice_controlling) {
 			JLOG_WARN("ICE role conflict (both controlling)");
 			if (agent->ice_tiebreaker >= msg->ice_controlling) {
 				JLOG_DEBUG("Asking remote peer to switch roles");
@@ -893,6 +902,7 @@ int agent_process_stun_binding(juice_agent_t *agent, const stun_message_t *msg,
 		}
 		if (msg->use_candidate) {
 			if (!msg->ice_controlling) {
+				JLOG_WARN("STUN message use_candidate missing ice_controlling attribute");
 				agent_send_stun_binding(agent, entry, STUN_CLASS_RESP_ERROR, 400,
 				                        msg->transaction_id, NULL);
 				return -1;
@@ -923,6 +933,7 @@ int agent_process_stun_binding(juice_agent_t *agent, const stun_message_t *msg,
 		           entry->type == AGENT_STUN_ENTRY_TYPE_CHECK ? "client" : "server");
 
 		entry->state = AGENT_STUN_ENTRY_STATE_SUCCEEDED;
+		entry->next_transmission = 0;
 
 		if (!agent->selected_pair || !agent->selected_pair->nominated) {
 			// We want to send keepalives now
@@ -941,21 +952,24 @@ int agent_process_stun_binding(juice_agent_t *agent, const stun_message_t *msg,
 		}
 		if (entry->type == AGENT_STUN_ENTRY_TYPE_CHECK) {
 			ice_candidate_pair_t *pair = entry->pair;
-			if (!pair->local && msg->mapped.len)
-				pair->local = ice_find_candidate_from_addr(&agent->local, &msg->mapped,
-				                                           ICE_CANDIDATE_TYPE_UNKNOWN);
+
 			if (pair->state != ICE_CANDIDATE_PAIR_STATE_SUCCEEDED) {
 				JLOG_DEBUG("Pair check succeeded");
 				pair->state = ICE_CANDIDATE_PAIR_STATE_SUCCEEDED;
 			}
-			if (pair->state == ICE_CANDIDATE_PAIR_STATE_SUCCEEDED) {
-				// RFC 8445 7.3.1.5. Updating the Nominated Flag:
-				// [...] once the check is sent and if it generates a successful response, and
-				// generates a valid pair, the agent sets the nominated flag of the pair to true.
-				if (pair->nomination_requested && agent->mode == AGENT_MODE_CONTROLLING) {
-					JLOG_DEBUG("Got a nominated pair (controlling)");
-					pair->nominated = true;
-				}
+
+			if (!pair->local && msg->mapped.len)
+				pair->local = ice_find_candidate_from_addr(&agent->local, &msg->mapped,
+				                                           ICE_CANDIDATE_TYPE_UNKNOWN);
+
+			// RFC 8445 7.3.1.5. Updating the Nominated Flag:
+			// [...] once the check is sent and if it generates a successful response, and
+			// generates a valid pair, the agent sets the nominated flag of the pair to true.
+			if (pair->nomination_requested) {
+				JLOG_DEBUG("Got a nominated pair (%s)", agent->mode == AGENT_MODE_CONTROLLING
+				           ? "controlling"
+				           : "controlled");
+				pair->nominated = true;
 			}
 		} else { // entry->type == AGENT_STUN_ENTRY_TYPE_SERVER
 			agent_update_gathering_done(agent);
@@ -980,10 +994,11 @@ int agent_process_stun_binding(juice_agent_t *agent, const stun_message_t *msg,
 				agent->mode = msg->ice_controlling ? AGENT_MODE_CONTROLLED : AGENT_MODE_CONTROLLING;
 				agent_update_candidate_pairs(agent);
 			}
-			entry->state = AGENT_STUN_ENTRY_STATE_PENDING;
-			entry->pair->state = ICE_CANDIDATE_PAIR_STATE_PENDING;
+
 			juice_random(&agent->ice_tiebreaker, sizeof(agent->ice_tiebreaker));
 
+			entry->state = AGENT_STUN_ENTRY_STATE_PENDING;
+			entry->pair->state = ICE_CANDIDATE_PAIR_STATE_PENDING;
 			agent_arm_transmission(agent, entry, 0);
 		}
 		break;
@@ -1004,7 +1019,7 @@ int agent_send_stun_binding(juice_agent_t *agent, const agent_stun_entry_t *entr
                             stun_class_t msg_class, unsigned int error_code,
                             const uint8_t *transaction_id, const addr_record_t *mapped) {
 	// Send STUN binding request
-	JLOG_DEBUG("Sending STUN binding %s",
+	JLOG_VERBOSE("Sending STUN binding %s",
 	           msg_class == STUN_CLASS_REQUEST
 	               ? "request"
 	               : (msg_class == STUN_CLASS_INDICATION ? "indication" : "response"));
@@ -1266,9 +1281,9 @@ void agent_arm_transmission(juice_agent_t *agent, agent_stun_entry_t *entry, tim
 	entry->next_transmission = current_timestamp() + delay;
 
 	if (entry->state == AGENT_STUN_ENTRY_STATE_PENDING) {
-		entry->retransmissions = (agent->mode == AGENT_MODE_CONTROLLING && agent->selected_pair)
-		                             ? 1
-		                             : MAX_STUN_RETRANSMISSION_COUNT;
+		bool limit = agent->selected_pair &&
+		             (agent->selected_pair->nominated || agent->mode == AGENT_MODE_CONTROLLING);
+		entry->retransmissions = limit ? 1 : MAX_STUN_RETRANSMISSION_COUNT;
 		entry->retransmission_timeout = MIN_STUN_RETRANSMISSION_TIMEOUT;
 	}
 
@@ -1310,13 +1325,18 @@ void agent_update_gathering_done(juice_agent_t *agent) {
 
 void agent_update_candidate_pairs(juice_agent_t *agent) {
 	bool is_controlling = agent->mode == AGENT_MODE_CONTROLLING;
-	for (int i = 0; i < agent->candidate_pairs_count; ++i)
-		ice_update_candidate_pair(is_controlling, agent->candidate_pairs + i);
+	for (int i = 0; i < agent->candidate_pairs_count; ++i) {
+		ice_candidate_pair_t *pair = agent->candidate_pairs + i;
+		ice_candidate_t *local = pair->local;
+		pair->local = NULL; // don't take local candidate into account
+		ice_update_candidate_pair(pair, is_controlling);
+		pair->local = local;
+	}
 	agent_update_ordered_pairs(agent);
 }
 
 void agent_update_ordered_pairs(juice_agent_t *agent) {
-	JLOG_VERBOSE("Updated ordered candidate pairs");
+	JLOG_VERBOSE("Updating ordered candidate pairs");
 	for (int i = 0; i < agent->candidate_pairs_count; ++i) {
 		ice_candidate_pair_t **begin = agent->ordered_pairs;
 		ice_candidate_pair_t **end = begin + i;
@@ -1364,19 +1384,18 @@ agent_stun_entry_t *agent_find_entry_from_record(juice_agent_t *agent,
 				return entry;
 			}
 		}
-	} else {
-		// Try to match entries directly
-		for (int i = 0; i < agent->entries_count; ++i) {
-			agent_stun_entry_t *entry = agent->entries + i;
-			if (addr_is_equal((struct sockaddr *)&entry->record.addr,
-			                  (struct sockaddr *)&record->addr, true)) {
-				JLOG_DEBUG("STUN entry %d matching incoming address", i);
-				return entry;
-			}
+	}
+
+	// Try to match entries directly
+	for (int i = 0; i < agent->entries_count; ++i) {
+		agent_stun_entry_t *entry = agent->entries + i;
+		if (addr_is_equal((struct sockaddr *)&entry->record.addr,
+		                  (struct sockaddr *)&record->addr, true)) {
+			JLOG_DEBUG("STUN entry %d matching incoming address", i);
+			return entry;
 		}
 	}
 
-	JLOG_DEBUG("No STUN entry matches incoming address");
 	return NULL;
 }
 
@@ -1414,6 +1433,8 @@ void agent_translate_host_candidate_entry(juice_agent_t *agent, agent_stun_entry
 			break;
 		}
 	}
+#else
+	(void)agent;
 #endif
 }
 

--- a/src/ice.c
+++ b/src/ice.c
@@ -358,10 +358,10 @@ int ice_create_candidate_pair(ice_candidate_t *local, ice_candidate_t *remote, b
 	pair->local = local;
 	pair->remote = remote;
 	pair->state = ICE_CANDIDATE_PAIR_STATE_FROZEN;
-	return ice_update_candidate_pair(is_controlling, pair);
+	return ice_update_candidate_pair(pair, is_controlling);
 }
 
-int ice_update_candidate_pair(bool is_controlling, ice_candidate_pair_t *pair) {
+int ice_update_candidate_pair(ice_candidate_pair_t *pair, bool is_controlling) {
 	// Compute pair priority according to RFC 8445
 	// See https://tools.ietf.org/html/rfc8445#section-6.1.2.3
 	uint64_t local_priority = pair->local ? pair->local->priority : 0;

--- a/src/ice.h
+++ b/src/ice.h
@@ -100,7 +100,7 @@ int ice_generate_sdp(const ice_description_t *description, char *buffer, size_t 
 int ice_generate_candidate_sdp(const ice_candidate_t *candidate, char *buffer, size_t size);
 int ice_create_candidate_pair(ice_candidate_t *local, ice_candidate_t *remote, bool is_controlling,
                               ice_candidate_pair_t *pair);
-int ice_update_candidate_pair(bool is_controlling, ice_candidate_pair_t *pair);
+int ice_update_candidate_pair(ice_candidate_pair_t *pair, bool is_controlling);
 
 int ice_candidates_count(const ice_description_t *description, ice_candidate_type_t type);
 

--- a/src/juice.c
+++ b/src/juice.c
@@ -71,6 +71,20 @@ JUICE_EXPORT int juice_send(juice_agent_t *agent, const char *data, size_t size)
 
 JUICE_EXPORT juice_state_t juice_get_state(juice_agent_t *agent) { return agent_get_state(agent); }
 
+JUICE_EXPORT int juice_get_selected_candidates(juice_agent_t *agent, char *local, size_t local_size,
+                                              char *remote, size_t remote_size) {
+	if (!agent || (!local && local_size) || (!remote && remote_size))
+		return -1;
+	ice_candidate_t local_cand, remote_cand;
+	if (agent_get_selected_candidate_pair(agent, &local_cand, &remote_cand))
+		return -1;
+	if (local_size && ice_generate_candidate_sdp(&local_cand, local, local_size) < 0)
+		return -1;
+	if (remote_size && ice_generate_candidate_sdp(&remote_cand, remote, remote_size) < 0)
+		return -1;
+	return 0;
+}
+
 JUICE_EXPORT int juice_get_selected_addresses(juice_agent_t *agent, char *local, size_t local_size,
                                               char *remote, size_t remote_size) {
 	if (!agent || (!local && local_size) || (!remote && remote_size))

--- a/test/connectivity.c
+++ b/test/connectivity.c
@@ -109,18 +109,32 @@ int test_connectivity() {
 	bool success = juice_get_state(agent1) == JUICE_STATE_COMPLETED &&
 	               juice_get_state(agent2) == JUICE_STATE_COMPLETED;
 
-	// Retrieve addresses
-	char local[JUICE_MAX_ADDRESS_STRING_LEN];
-	char remote[JUICE_MAX_ADDRESS_STRING_LEN];
-	if (success &= (juice_get_selected_addresses(agent1, local, JUICE_MAX_ADDRESS_STRING_LEN,
-	                                             remote, JUICE_MAX_ADDRESS_STRING_LEN) == 0)) {
-		printf("Local address  1: %s\n", local);
-		printf("Remote address 1: %s\n", remote);
+	// Retrieve candidates
+	char local[JUICE_MAX_CANDIDATE_SDP_STRING_LEN];
+	char remote[JUICE_MAX_CANDIDATE_SDP_STRING_LEN];
+	if (success &= (juice_get_selected_candidates(agent1, local, JUICE_MAX_CANDIDATE_SDP_STRING_LEN,
+	                                             remote, JUICE_MAX_CANDIDATE_SDP_STRING_LEN) == 0)) {
+		printf("Local candidate  1: %s\n", local);
+		printf("Remote candidate 1: %s\n", remote);
 	}
-	if (success &= (juice_get_selected_addresses(agent2, local, JUICE_MAX_ADDRESS_STRING_LEN,
-	                                             remote, JUICE_MAX_ADDRESS_STRING_LEN) == 0)) {
-		printf("Local address  2: %s\n", local);
-		printf("Remote address 2: %s\n", remote);
+	if (success &= (juice_get_selected_candidates(agent2, local, JUICE_MAX_CANDIDATE_SDP_STRING_LEN,
+	                                             remote, JUICE_MAX_CANDIDATE_SDP_STRING_LEN) == 0)) {
+		printf("Local candidate  2: %s\n", local);
+		printf("Remote candidate 2: %s\n", remote);
+	}
+	
+	// Retrieve addresses
+	char localAddr[JUICE_MAX_ADDRESS_STRING_LEN];
+	char remoteAddr[JUICE_MAX_ADDRESS_STRING_LEN];
+	if (success &= (juice_get_selected_addresses(agent1, localAddr, JUICE_MAX_ADDRESS_STRING_LEN,
+	                                             remoteAddr, JUICE_MAX_ADDRESS_STRING_LEN) == 0)) {
+		printf("Local address  1: %s\n", localAddr);
+		printf("Remote address 1: %s\n", remoteAddr);
+	}
+	if (success &= (juice_get_selected_addresses(agent2, localAddr, JUICE_MAX_ADDRESS_STRING_LEN,
+	                                             remoteAddr, JUICE_MAX_ADDRESS_STRING_LEN) == 0)) {
+		printf("Local address  2: %s\n", localAddr);
+		printf("Remote address 2: %s\n", remoteAddr);
 	}
 
 	// Agent 1: destroy

--- a/test/connectivity.c
+++ b/test/connectivity.c
@@ -106,8 +106,9 @@ int test_connectivity() {
 	// -- Connection should be finished --
 
 	// Check states
-	bool success = juice_get_state(agent1) == JUICE_STATE_COMPLETED &&
-	               juice_get_state(agent2) == JUICE_STATE_COMPLETED;
+	juice_state_t state1 = juice_get_state(agent1);
+	juice_state_t state2 = juice_get_state(agent2);
+	bool success = (state1 == JUICE_STATE_COMPLETED && state2 == JUICE_STATE_COMPLETED);
 
 	// Retrieve candidates
 	char local[JUICE_MAX_CANDIDATE_SDP_STRING_LEN];
@@ -122,7 +123,7 @@ int test_connectivity() {
 		printf("Local candidate  2: %s\n", local);
 		printf("Remote candidate 2: %s\n", remote);
 	}
-	
+
 	// Retrieve addresses
 	char localAddr[JUICE_MAX_ADDRESS_STRING_LEN];
 	char remoteAddr[JUICE_MAX_ADDRESS_STRING_LEN];

--- a/test/notrickle.c
+++ b/test/notrickle.c
@@ -85,18 +85,32 @@ int test_notrickle() {
 	bool success = juice_get_state(agent1) == JUICE_STATE_COMPLETED &&
 	               juice_get_state(agent2) == JUICE_STATE_COMPLETED;
 
-	// Retrieve addresses
-	char local[JUICE_MAX_ADDRESS_STRING_LEN];
-	char remote[JUICE_MAX_ADDRESS_STRING_LEN];
-	if (success &= (juice_get_selected_addresses(agent1, local, JUICE_MAX_ADDRESS_STRING_LEN,
-	                                             remote, JUICE_MAX_ADDRESS_STRING_LEN) == 0)) {
-		printf("Local address  1: %s\n", local);
-		printf("Remote address 1: %s\n", remote);
+	// Retrieve candidates
+	char local[JUICE_MAX_CANDIDATE_SDP_STRING_LEN];
+	char remote[JUICE_MAX_CANDIDATE_SDP_STRING_LEN];
+	if (success &= (juice_get_selected_candidates(agent1, local, JUICE_MAX_CANDIDATE_SDP_STRING_LEN,
+	                                             remote, JUICE_MAX_CANDIDATE_SDP_STRING_LEN) == 0)) {
+		printf("Local candidate  1: %s\n", local);
+		printf("Remote candidate 1: %s\n", remote);
 	}
-	if (success &= (juice_get_selected_addresses(agent2, local, JUICE_MAX_ADDRESS_STRING_LEN,
-	                                             remote, JUICE_MAX_ADDRESS_STRING_LEN) == 0)) {
-		printf("Local address  2: %s\n", local);
-		printf("Remote address 2: %s\n", remote);
+	if (success &= (juice_get_selected_candidates(agent2, local, JUICE_MAX_CANDIDATE_SDP_STRING_LEN,
+	                                             remote, JUICE_MAX_CANDIDATE_SDP_STRING_LEN) == 0)) {
+		printf("Local candidate  2: %s\n", local);
+		printf("Remote candidate 2: %s\n", remote);
+	}
+	
+	// Retrieve addresses
+	char localAddr[JUICE_MAX_ADDRESS_STRING_LEN];
+	char remoteAddr[JUICE_MAX_ADDRESS_STRING_LEN];
+	if (success &= (juice_get_selected_addresses(agent1, localAddr, JUICE_MAX_ADDRESS_STRING_LEN,
+	                                             remoteAddr, JUICE_MAX_ADDRESS_STRING_LEN) == 0)) {
+		printf("Local address  1: %s\n", localAddr);
+		printf("Remote address 1: %s\n", remoteAddr);
+	}
+	if (success &= (juice_get_selected_addresses(agent2, localAddr, JUICE_MAX_ADDRESS_STRING_LEN,
+	                                             remoteAddr, JUICE_MAX_ADDRESS_STRING_LEN) == 0)) {
+		printf("Local address  2: %s\n", localAddr);
+		printf("Remote address 2: %s\n", remoteAddr);
 	}
 
 	// Agent 1: destroy

--- a/test/notrickle.c
+++ b/test/notrickle.c
@@ -82,8 +82,9 @@ int test_notrickle() {
 	// -- Connection should be finished --
 
 	// Check states
-	bool success = juice_get_state(agent1) == JUICE_STATE_COMPLETED &&
-	               juice_get_state(agent2) == JUICE_STATE_COMPLETED;
+	juice_state_t state1 = juice_get_state(agent1);
+	juice_state_t state2 = juice_get_state(agent2);
+	bool success = (state1 == JUICE_STATE_COMPLETED && state2 == JUICE_STATE_COMPLETED);
 
 	// Retrieve candidates
 	char local[JUICE_MAX_CANDIDATE_SDP_STRING_LEN];
@@ -98,7 +99,7 @@ int test_notrickle() {
 		printf("Local candidate  2: %s\n", local);
 		printf("Remote candidate 2: %s\n", remote);
 	}
-	
+
 	// Retrieve addresses
 	char localAddr[JUICE_MAX_ADDRESS_STRING_LEN];
 	char remoteAddr[JUICE_MAX_ADDRESS_STRING_LEN];


### PR DESCRIPTION
This PR introduces a new getter `juice_get_selected_candidates` to get the selected candidates pair.
It also enhances the completion logic and keeps local address translation only on macOS.