### PR TITLE
Remove wsock32 for uwp compatibility.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,10 +77,10 @@ target_link_libraries(juice-static PUBLIC Threads::Threads)
 
 if(WIN32)
 	target_link_libraries(juice PRIVATE
-		wsock32 ws2_32 # winsock2
+		ws2_32 # winsock2
 		bcrypt)
 	target_link_libraries(juice-static PRIVATE
-		wsock32 ws2_32 # winsock2
+		ws2_32 # winsock2
 		bcrypt)
 endif()
 


### PR DESCRIPTION
wsock32 is for the obsolete version of Windows Socket. libjuice is linked to ws2_32 (one for Windows Socket 2) and this is enough for calling Windows Socket APIs. More than that, the inclusion of wsock32 is incompatible with the Universal Windows App thing that Microsoft is pushing. To upload an app to their store, the app should comply to their sandbox environment thing, and inclusion of wsock32 is considered as a violation...

In case you want to know where I got this information from...
https://stackoverflow.com/questions/17797594/winsock2-h-vs-winsock2-h-and-wsock32-lib-vs-ws2-32-lib