### PR TITLE
Check glibc version before using getrandom()

### DIFF
--- a/src/random.c
+++ b/src/random.c
@@ -24,7 +24,9 @@
 #include <stdbool.h>
 #include <time.h>
 
-#if defined(__linux__) && !defined(__ANDROID__) // getrandom() not available in Android NDK API < 28
+// getrandom() is not available in Android NDK API < 28 and needs glibc >= 2.25
+#if defined(__linux__) && !defined(__ANDROID__) && (!defined(__GLIBC__) || __GLIBC__ > 2 || __GLIBC_MINOR__ >= 25)
+
 #include <errno.h>
 #include <sys/random.h>
 


### PR DESCRIPTION
`getrandom()` requires glibc 2.25+.

Fixes https://github.com/paullouisageneau/libjuice/issues/54