### PR TITLE
Fix deadlock while waiting for data

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -454,12 +454,12 @@ void agent_run(juice_agent_t *agent) {
 		}
 
 		if (FD_ISSET(agent->sock, &readfds)) {
-			mutex_lock(&agent->mutex);
+			mutex_unlock(&agent->mutex);
 			if (agent_recv(agent) < 0) {
-				mutex_unlock(&agent->mutex);
+				mutex_lock(&agent->mutex);
 				break;
 			}
-			mutex_unlock(&agent->mutex);
+			mutex_lock(&agent->mutex);
 		}
 	}
 	JLOG_DEBUG("Leaving agent thread");

--- a/src/agent.c
+++ b/src/agent.c
@@ -454,8 +454,12 @@ void agent_run(juice_agent_t *agent) {
 		}
 
 		if (FD_ISSET(agent->sock, &readfds)) {
-			if (agent_recv(agent) < 0)
+			mutex_lock(&agent->mutex);
+			if (agent_recv(agent) < 0) {
+				mutex_unlock(&agent->mutex);
 				break;
+			}
+			mutex_unlock(&agent->mutex);
 		}
 	}
 	JLOG_DEBUG("Leaving agent thread");


### PR DESCRIPTION
I'm not 100% sure about this one. It was happening only in one PC (every time) while the other one was working.

When running a paullouisageneau/libdatachannel connection between two PCs with a media track with Direction::SendRecv, one of them would get stuck in this call and wouldn't be able to send data because the other thread is waiting for the lock to be released.

This change fixed the problem. But I'm not sure if the agent_recv call is thread safe.