### PR TITLE
Added the candidate filter callback

### DIFF
--- a/include/juice/juice.h
+++ b/include/juice/juice.h
@@ -57,6 +57,7 @@ typedef enum juice_state {
 
 typedef void (*juice_cb_state_changed_t)(juice_agent_t *agent, juice_state_t state, void *user_ptr);
 typedef void (*juice_cb_candidate_t)(juice_agent_t *agent, const char *sdp, void *user_ptr);
+typedef bool (*juice_cb_filter_candidate_t)(juice_agent_t *agent, const char *sdp, void *user_ptr);
 typedef void (*juice_cb_gathering_done_t)(juice_agent_t *agent, void *user_ptr);
 typedef void (*juice_cb_recv_t)(juice_agent_t *agent, const char *data, size_t size,
                                 void *user_ptr);
@@ -82,6 +83,7 @@ typedef struct juice_config {
 	juice_cb_candidate_t cb_candidate;
 	juice_cb_gathering_done_t cb_gathering_done;
 	juice_cb_recv_t cb_recv;
+	juice_cb_filter_candidate_t cb_filter_candidate;
 
 	void *user_ptr;
 

--- a/test/connectivity.c
+++ b/test/connectivity.c
@@ -59,6 +59,7 @@ int test_connectivity() {
 	config1.cb_candidate = on_candidate1;
 	config1.cb_gathering_done = on_gathering_done1;
 	config1.cb_recv = on_recv1;
+	config1.cb_filter_candidate = NULL;
 	config1.user_ptr = NULL;
 
 	agent1 = juice_create(&config1);
@@ -72,6 +73,7 @@ int test_connectivity() {
 	config2.cb_candidate = on_candidate2;
 	config2.cb_gathering_done = on_gathering_done2;
 	config2.cb_recv = on_recv2;
+    config2.cb_filter_candidate = NULL;
 	config2.user_ptr = NULL;
 	// Port range example
 	config2.local_port_range_begin = 60000;

--- a/test/notrickle.c
+++ b/test/notrickle.c
@@ -55,6 +55,7 @@ int test_notrickle() {
 	config1.cb_state_changed = on_state_changed1;
 	config1.cb_gathering_done = on_gathering_done1;
 	config1.cb_recv = on_recv1;
+	config1.cb_filter_candidate = NULL;
 	config1.user_ptr = NULL;
 
 	agent1 = juice_create(&config1);
@@ -67,6 +68,7 @@ int test_notrickle() {
 	config2.cb_state_changed = on_state_changed2;
 	config2.cb_gathering_done = on_gathering_done2;
 	config2.cb_recv = on_recv2;
+	config2.cb_filter_candidate = NULL;
 	config2.user_ptr = NULL;
 	// Port range example
 	config2.local_port_range_begin = 60000;

--- a/test/server.c
+++ b/test/server.c
@@ -66,6 +66,7 @@ int test_server() {
 	config.cb_state_changed = on_state_changed;
 	config.cb_candidate = on_candidate;
 	config.cb_gathering_done = on_gathering_done;
+	config.cb_filter_candidate = NULL;
 	config.user_ptr = NULL;
 
 	agent = juice_create(&config);

--- a/test/turn.c
+++ b/test/turn.c
@@ -73,6 +73,7 @@ int test_turn() {
 	config1.cb_candidate = on_candidate1;
 	config1.cb_gathering_done = on_gathering_done1;
 	config1.cb_recv = on_recv1;
+	config1.cb_filter_candidate = NULL;
 	config1.user_ptr = NULL;
 
 	agent1 = juice_create(&config1);
@@ -93,6 +94,7 @@ int test_turn() {
 	config2.cb_candidate = on_candidate2;
 	config2.cb_gathering_done = on_gathering_done2;
 	config2.cb_recv = on_recv2;
+	config2.cb_filter_candidate = NULL;
 	config2.user_ptr = NULL;
 
 	agent2 = juice_create(&config2);


### PR DESCRIPTION
This PR allows for local candidates to be filtered so candidates that are known by the application to not work are not offered to the peer.