### PR TITLE
Fix thread interruption when loopback has no IPv6

### DIFF
--- a/src/udp.h
+++ b/src/udp.h
@@ -34,7 +34,7 @@ socket_t udp_create_socket(const udp_socket_config_t *config);
 int udp_set_diffserv(socket_t sock, int ds);
 uint16_t udp_get_port(socket_t sock);
 int udp_get_bound_addr(socket_t sock, addr_record_t *record);
-int udp_get_local_addr(socket_t sock, addr_record_t *record);
+int udp_get_local_addr(socket_t sock, int family, addr_record_t *record); // family may be AF_UNSPEC
 int udp_get_addrs(socket_t sock, addr_record_t *records, size_t count);
 
 #endif // JUICE_UDP_H


### PR DESCRIPTION
This PR fixes thread interruption when the host supports IPv6 but it has been disabled on loopback, for instance with `net.ipv6.conf.all.disable_ipv6 = 1`.

Fixes https://github.com/paullouisageneau/libjuice/issues/79