### PR TITLE
Hide not exported symbols by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,15 @@ endif()
 add_library(LibJuice::LibJuice ALIAS juice)
 add_library(LibJuice::LibJuiceStatic ALIAS juice-static)
 
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.12")
+	include(GenerateExportHeader)
+	generate_export_header(juice)
+	target_include_directories(juice PUBLIC ${CMAKE_BINARY_DIR})
+	target_compile_definitions(juice PUBLIC -DJUICE_HAS_EXPORT_HEADER)
+	set_target_properties(juice PROPERTIES C_VISIBILITY_PRESET hidden)
+	install(FILES ${PROJECT_BINARY_DIR}/juice_export.h DESTINATION include/juice)
+endif()
+
 install(TARGETS juice LIBRARY DESTINATION lib)
 install(FILES ${LIBJUICE_HEADERS} DESTINATION include/juice)
 

--- a/include/juice/juice.h
+++ b/include/juice/juice.h
@@ -27,10 +27,14 @@ extern "C" {
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef JUICE_HAS_EXPORT_HEADER
+#include "juice_export.h"
+#else
 #ifdef _WIN32
 #define JUICE_EXPORT __declspec(dllexport)
 #else
 #define JUICE_EXPORT
+#endif
 #endif
 
 #define JUICE_ERR_SUCCESS 0


### PR DESCRIPTION
Right now on Linux all symbols, including those that are not part of the public API, are exported.
If juice is dynamically linked to a codebase that contains a symbol with the same name, juice
will use that one instead of its own version of that symbol. This can cause crashes or other types of instabilities.

This pull request causes symbols not marked with JUICE_EXPORT to be hidden to reduce
possible symbol collisions.

Hiding is accomplished with CMake C_VISIBILITY_PRESET option, which
automatically uses appropriate compiler option (-fvisibility on GCC).

This commit also replaces the JUICE_EXPORT macro by one automatically
generated by CMake, which should contain the appropriate definition for
the used compiler.