### PR TITLE
Add TURN ALTERNATE-SERVER mechanism for agent

### DIFF
--- a/src/agent.h
+++ b/src/agent.h
@@ -62,6 +62,9 @@
 #define MAX_SERVER_ENTRIES_COUNT 2 // max STUN server entries
 #define MAX_RELAY_ENTRIES_COUNT 2  // max TURN server entries
 
+// Max TURN redirections for ALTERNATE-SERVER mechanism
+#define MAX_TURN_REDIRECTIONS 1
+
 // Compute max candidates and entries count
 // This guarantees 8 (+1 to be safe) host candidates slots
 #define MAX_STUN_SERVER_RECORDS_COUNT MAX_SERVER_ENTRIES_COUNT
@@ -114,6 +117,7 @@ typedef struct agent_stun_entry {
 
 	// TURN
 	agent_turn_state_t *turn;
+	unsigned int turn_redirections;
 	struct agent_stun_entry *relay_entry;
 
 #ifdef NO_ATOMICS

--- a/src/stun.c
+++ b/src/stun.c
@@ -654,6 +654,13 @@ int stun_read_attr(const void *data, size_t size, stun_message_t *msg, uint8_t *
 			return -1;
 		break;
 	}
+	case STUN_ATTR_ALTERNATE_SERVER: {
+		JLOG_VERBOSE("Reading alternate server");
+		uint8_t zero_mask[16] = {0};
+		if (stun_read_value_mapped_address(attr->value, length, &msg->alternate_server, zero_mask) < 0)
+			return -1;
+		break;
+	}
 	case STUN_ATTR_ERROR_CODE: {
 		JLOG_VERBOSE("Reading error code");
 		if (length < sizeof(struct stun_value_error_code)) {

--- a/src/stun.h
+++ b/src/stun.h
@@ -333,12 +333,13 @@ typedef struct stun_message {
 	bool has_fingerprint;
 
 	// TURN
-	uint16_t channel_number;
 	addr_record_t peer;
 	addr_record_t relayed;
+	addr_record_t alternate_server;
 	const char *data;
 	size_t data_size;
 	uint32_t lifetime;
+	uint16_t channel_number;
 	bool lifetime_set;
 	bool even_port;
 	bool next_port;


### PR DESCRIPTION
This PR implements the ALTERNATE-SERVER mechanism from [RFC 8489](https://datatracker.ietf.org/doc/html/rfc8489#section-10).

Implements https://github.com/paullouisageneau/libjuice/issues/88