### PR TITLE
Add dynamic TURN credentials

### DIFF
--- a/include/juice/juice.h
+++ b/include/juice/juice.h
@@ -112,7 +112,6 @@ JUICE_EXPORT int juice_get_selected_addresses(juice_agent_t *agent, char *local,
                                               char *remote, size_t remote_size);
 JUICE_EXPORT const char *juice_state_to_string(juice_state_t state);
 
-
 // ICE server
 
 typedef struct juice_server juice_server_t;
@@ -145,7 +144,9 @@ JUICE_EXPORT juice_server_t *juice_server_create(const juice_server_config_t *co
 JUICE_EXPORT void juice_server_destroy(juice_server_t *server);
 
 JUICE_EXPORT uint16_t juice_server_get_port(juice_server_t *server);
-
+JUICE_EXPORT int juice_server_add_credentials(juice_server_t *server,
+                                              const juice_server_credentials_t *credentials,
+                                              unsigned int lifetime_ms);
 
 // Logging
 

--- a/src/juice.c
+++ b/src/juice.c
@@ -196,3 +196,22 @@ JUICE_EXPORT uint16_t juice_server_get_port(juice_server_t *server) {
 	return 0;
 #endif
 }
+
+JUICE_EXPORT int juice_server_add_credentials(juice_server_t *server,
+                                              const juice_server_credentials_t *credentials,
+                                              unsigned int lifetime_ms) {
+#ifndef NO_SERVER
+	if (!server || !credentials)
+		return JUICE_ERR_INVALID;
+
+	if (server_add_credentials(server, credentials, (timediff_t)lifetime_ms) < 0)
+		return JUICE_ERR_FAILED;
+
+	return JUICE_ERR_SUCCESS;
+#else
+	(void)server;
+	(void)credentials;
+	(void)lifetime_ms;
+	return JUICE_ERR_INVALID;
+#endif
+}

--- a/src/server.h
+++ b/src/server.h
@@ -62,9 +62,16 @@ typedef struct server_turn_alloc {
 	turn_map_t map;
 } server_turn_alloc_t;
 
+typedef struct juice_credentials_list {
+	struct juice_credentials_list *next;
+	juice_server_credentials_t credentials;
+	uint8_t userhash[USERHASH_SIZE];
+	timestamp_t timestamp;
+} juice_credentials_list_t;
+
 typedef struct juice_server {
-	juice_server_config_t config;
-	uint8_t **credentials_userhash;
+	juice_server_config_t config;          // Note config.credentials will be empty
+	juice_credentials_list_t *credentials; // Credentials are stored in this list
 	uint8_t nonce_key[SERVER_NONCE_KEY_SIZE];
 	timestamp_t nonce_key_timestamp;
 	socket_t sock;
@@ -80,6 +87,12 @@ void server_do_destroy(juice_server_t *server);
 void server_destroy(juice_server_t *server);
 
 uint16_t server_get_port(juice_server_t *server);
+int server_add_credentials(juice_server_t *server, const juice_server_credentials_t *credentials,
+                           timediff_t lifetime);
+
+juice_credentials_list_t *server_do_add_credentials(juice_server_t *server,
+                                                    const juice_server_credentials_t *credentials,
+                                                    timediff_t lifetime); // internal
 
 void server_run(juice_server_t *server);
 int server_send(juice_server_t *agent, const addr_record_t *dst, const char *data, size_t size);

--- a/src/stun.c
+++ b/src/stun.c
@@ -273,7 +273,7 @@ int stun_write(void *buf, size_t size, const stun_message_t *msg, const char *pa
 	if (msg->msg_class == STUN_CLASS_REQUEST) {
 		if (msg->credentials.enable_userhash) {
 			len = stun_write_attr(pos, end - pos, STUN_ATTR_USERHASH, msg->credentials.userhash,
-			                      HASH_SHA256_SIZE);
+			                      USERHASH_SIZE);
 			if (len <= 0)
 				goto overflow;
 			pos += len;
@@ -867,11 +867,11 @@ int stun_read_attr(const void *data, size_t size, stun_message_t *msg, uint8_t *
 	}
 	case STUN_ATTR_USERHASH: {
 		JLOG_VERBOSE("Reading user hash");
-		if (length != HASH_SHA256_SIZE) {
+		if (length != USERHASH_SIZE) {
 			JLOG_WARN("STUN user hash value too long, length=%zu", length);
 			return -1;
 		}
-		memcpy(msg->credentials.userhash, attr->value, HASH_SHA256_SIZE);
+		memcpy(msg->credentials.userhash, attr->value, USERHASH_SIZE);
 		msg->credentials.enable_userhash = true;
 		break;
 	}

--- a/src/stun.h
+++ b/src/stun.h
@@ -292,6 +292,9 @@ typedef enum stun_password_algorithm {
 #define STUN_NONCE_COOKIE "obMatJos2"
 #define STUN_NONCE_COOKIE_LEN 9
 
+// USERHASH is a SHA256 digest
+#define USERHASH_SIZE HASH_SHA256_SIZE
+
 // STUN Security Feature bits as defined in https://tools.ietf.org/html/rfc8489#section-18.1
 // See errata about bit order: https://www.rfc-editor.org/errata_search.php?rfc=8489
 // Bits are assigned starting from the least significant side of the bit set, so Bit 0 is the rightmost bit, and Bit 23 is the leftmost bit.
@@ -308,7 +311,7 @@ typedef struct stun_credentials {
 	char username[STUN_MAX_USERNAME_LEN];
 	char realm[STUN_MAX_REALM_LEN];
 	char nonce[STUN_MAX_NONCE_LEN];
-	uint8_t userhash[HASH_SHA256_SIZE];
+	uint8_t userhash[USERHASH_SIZE];
 	bool enable_userhash;
 	stun_password_algorithm_t password_algorithm;
 	uint8_t password_algorithms_value[STUN_MAX_PASSWORD_ALGORITHMS_VALUE_SIZE];


### PR DESCRIPTION
This PR refactors TURN credentials storage and adds the function `juice_server_add_credentials()` to dynamically add credentials.