### PR TITLE
Replace select() by poll()

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -290,6 +290,13 @@ uint16_t server_get_port(juice_server_t *server) {
 }
 
 void server_run(juice_server_t *server) {
+	const nfds_t nfd = 1 + server->allocs_count;
+	struct pollfd *pfd = calloc(nfd, sizeof(struct pollfd));
+	if(!pfd) {
+		JLOG_FATAL("alloc for poll descriptors failed");
+		return;
+	}
+
 	mutex_lock(&server->mutex);
 
 	// Main loop
@@ -299,60 +306,59 @@ void server_run(juice_server_t *server) {
 		if (timediff < 0)
 			timediff = 0;
 
-		JLOG_VERBOSE("Setting select timeout to %ld ms", (long)timediff);
-		struct timeval timeout;
-		timeout.tv_sec = (long)(timediff / 1000);
-		timeout.tv_usec = (long)((timediff % 1000) * 1000);
+		pfd[0].fd = server->sock;
+		pfd[0].events = POLLIN;
 
-		fd_set readfds;
-		FD_ZERO(&readfds);
-		FD_SET(server->sock, &readfds);
-		int max = SOCKET_TO_INT(server->sock);
-
-		int count = 1;
 		for (int i = 0; i < server->allocs_count; ++i) {
 			server_turn_alloc_t *alloc = server->allocs + i;
 			if (alloc->state == SERVER_TURN_ALLOC_FULL) {
-				++count;
-				FD_SET(alloc->sock, &readfds);
-				if (max < SOCKET_TO_INT(alloc->sock))
-					max = SOCKET_TO_INT(alloc->sock);
+				pfd[1 + i].fd = alloc->sock;
+				pfd[1 + i].events = POLLIN;
+			} else {
+				pfd[1 + i].fd = -1; // ignore
 			}
 		}
 
-		JLOG_VERBOSE("Entering select on %d socket(s)", count);
+		JLOG_VERBOSE("Entering poll for %d ms", (int)timediff);
 		mutex_unlock(&server->mutex);
-		int ret = select(max + 1, &readfds, NULL, NULL, &timeout);
+		int ret = poll(pfd, nfd, (int)timediff);
 		mutex_lock(&server->mutex);
-		JLOG_VERBOSE("Leaving select");
+		JLOG_VERBOSE("Leaving poll");
 		if (ret < 0) {
 			if (sockerrno == SEINTR || sockerrno == SEAGAIN) {
-				JLOG_VERBOSE("select interrupted");
+				JLOG_VERBOSE("poll interrupted");
 				continue;
 			} else {
-				JLOG_FATAL("select failed, errno=%d", sockerrno);
+				JLOG_FATAL("poll failed, errno=%d", sockerrno);
 				break;
 			}
 		}
 
 		if (server->thread_stopped) {
-			JLOG_VERBOSE("Agent destruction requested");
+			JLOG_VERBOSE("Server destruction requested");
 			break;
+		}
+
+		if (pfd[0].revents & POLLNVAL || pfd[0].revents & POLLERR) {
+			JLOG_FATAL("Error when polling server socket");
+			break;
+		}
+
+		if (pfd[0].revents & POLLIN) {
+			if (server_recv(server) < 0)
+				break;
 		}
 
 		for (int i = 0; i < server->allocs_count; ++i) {
 			server_turn_alloc_t *alloc = server->allocs + i;
-			if (alloc->state == SERVER_TURN_ALLOC_FULL && FD_ISSET(alloc->sock, &readfds))
+			if (alloc->state == SERVER_TURN_ALLOC_FULL && pfd[1 + i].revents & POLLIN)
 				server_forward(server, alloc);
 		}
-
-		if (FD_ISSET(server->sock, &readfds)) {
-			if (server_recv(server) < 0)
-				break;
-		}
 	}
+
 	JLOG_DEBUG("Leaving server thread");
 	mutex_unlock(&server->mutex);
+	free(pfd);
 }
 
 int server_send(juice_server_t *server, const addr_record_t *dst, const char *data, size_t size) {

--- a/src/socket.h
+++ b/src/socket.h
@@ -31,8 +31,8 @@
 #include <winsock2.h>
 #include <ws2tcpip.h>
 //
-#include <windows.h>
 #include <iphlpapi.h>
+#include <windows.h>
 
 #ifdef __MINGW32__
 #include <sys/stat.h>
@@ -47,12 +47,14 @@
 
 typedef SOCKET socket_t;
 typedef SOCKADDR sockaddr;
-typedef u_long ctl_t;
+typedef ULONG ctl_t;
 typedef DWORD sockopt_t;
 #define sockerrno ((int)WSAGetLastError())
 #define IP_DONTFRAG IP_DONTFRAGMENT
-#define SOCKET_TO_INT(x) 0
 #define HOST_NAME_MAX 256
+
+#define poll WSAPoll
+typedef ULONG nfds_t;
 
 #define SEADDRINUSE WSAEADDRINUSE
 #define SEINTR WSAEINTR
@@ -74,6 +76,7 @@ typedef DWORD sockopt_t;
 #include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <poll.h>
 #include <sys/ioctl.h>
 #include <sys/select.h>
 #include <sys/socket.h>
@@ -97,7 +100,6 @@ typedef int ctl_t;
 typedef int sockopt_t;
 #define sockerrno errno
 #define INVALID_SOCKET -1
-#define SOCKET_TO_INT(x) (x)
 #define ioctlsocket ioctl
 #define closesocket close
 


### PR DESCRIPTION
This PR replaces `select()` by `poll()`, whose behavior is nowadays available on Microsoft Windows with `WSAPoll()`, to fix the limitation to 1024 file descriptors.