### PR TITLE
Reduce server default max allocations count

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -33,7 +33,7 @@
 #include <stdint.h>
 
 #define SERVER_DEFAULT_REALM "libjuice"
-#define SERVER_DEFAULT_MAX_ALLOCATIONS 1024
+#define SERVER_DEFAULT_MAX_ALLOCATIONS 1000 // should be 1024-1 or less to be safe for poll()
 #define SERVER_DEFAULT_MAX_PEERS 16
 
 #define SERVER_NONCE_KEY_SIZE 32


### PR DESCRIPTION
This PR reduces the default max allocations count in server to 1000 to fix https://github.com/paullouisageneau/libjuice/issues/127.