### PR TITLE
Fix: Windows 7 ipv4 address sendto errno=10049

### DIFF
--- a/src/udp.c
+++ b/src/udp.c
@@ -71,7 +71,7 @@ socket_t udp_create_socket(const udp_socket_config_t *config) {
 
 	// Prefer IPv6
 	struct addrinfo *ai;
-	if ((ai = find_family(ai_list, AF_INET6)) == NULL &&
+	if ((ai = find_family(ai_list, AF_INET6)) == NULL ||
 	    (ai = find_family(ai_list, AF_INET)) == NULL) {
 		JLOG_ERROR("getaddrinfo for binding address failed: no suitable "
 		           "address family");


### PR DESCRIPTION
Hello, Paul-Louis Ageneau

When windows7 tested libdatachannel, it sent errno=10049, but it was normal on windows 10. It was found that libjuice caused this problem.
It has been fixed to test ok on windows7/windows10

error log
```
2021-10-22 15:00:36.900 WARN  [8420] [rtc::impl::IceTransport::LogCallback@345] juice: agent.c:419: Send failed, errno=10049
2021-10-22 15:00:36.900 WARN  [8420] [rtc::impl::IceTransport::LogCallback@345] juice: agent.c:769: Failed to interrupt thread by triggering socket
State 2: connecting
2021-10-22 15:00:37.118 WARN  [9632] [rtc::impl::IceTransport::LogCallback@345] juice: agent.c:419: Send failed, errno=10049
2021-10-22 15:00:37.119 WARN  [9632] [rtc::impl::IceTransport::LogCallback@345] juice: agent.c:1560: STUN message send failed
Candidate 1: a=candidate:2 1 UDP 1686110207 61.130.11.220 57786 typ srflx raddr 0.0.0.0 rport 0
2021-10-22 15:00:37.123 WARN  [20292] [rtc::impl::IceTransport::LogCallback@345] juice: agent.c:419: Send failed, errno=10049
2021-10-22 15:00:37.124 WARN  [20292] [rtc::impl::IceTransport::LogCallback@345] juice: agent.c:769: Failed to interrupt thread by triggering socket
Gathering state 1: complete
2021-10-22 15:00:37.134 WARN  [11988] [rtc::impl::IceTransport::LogCallback@345] juice: agent.c:419: Send failed, errno=10049
2021-10-22 15:00:37.136 WARN  [11988] [rtc::impl::IceTransport::LogCallback@345] juice: agent.c:1560: STUN message send failed
Candidate 2: a=candidate:2 1 UDP 1686110207 61.130.11.220 57787 typ srflx raddr 0.0.0.0 rport 0
2021-10-22 15:00:37.139 WARN  [8420] [rtc::impl::IceTransport::LogCallback@345] juice: agent.c:419: Send failed, errno=10049
2021-10-22 15:00:37.140 WARN  [8420] [rtc::impl::IceTransport::LogCallback@345] juice: agent.c:769: Failed to interrupt thread by triggering socket
Gathering state 2: complete
```