### PR TITLE
Enhance socket interrupt to properly support IPv6-only

### DIFF
--- a/src/udp.h
+++ b/src/udp.h
@@ -33,6 +33,7 @@ typedef struct udp_socket_config {
 socket_t udp_create_socket(const udp_socket_config_t *config);
 int udp_recvfrom(socket_t sock, char *buffer, size_t size, addr_record_t *src);
 int udp_sendto(socket_t sock, const char *data, size_t size, const addr_record_t *dst);
+int udp_sendto_self(socket_t sock, const char *data, size_t size);
 int udp_set_diffserv(socket_t sock, int ds);
 uint16_t udp_get_port(socket_t sock);
 int udp_get_bound_addr(socket_t sock, addr_record_t *record);


### PR DESCRIPTION
This PR enhances socket interrupt to properly support IPv6-only hosts. The logic is now to try the address family of the socket first, then fallback to IPv4.