### PR TITLE
Fix candidate priority computation

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -1510,7 +1510,7 @@ int agent_send_stun_binding(juice_agent_t *agent, agent_stun_entry_t *entry, stu
 			// candidate type preference of peer-reflexive candidates.
 			int family = entry->record.addr.ss_family;
 			int index = entry->pair && entry->pair->local
-			                ? entry->pair->local - agent->local.candidates
+			                ? (int)(entry->pair->local - agent->local.candidates)
 			                : 0;
 			msg.priority =
 			    ice_compute_priority(ICE_CANDIDATE_TYPE_PEER_REFLEXIVE, family, 1, index);

--- a/src/ice.h
+++ b/src/ice.h
@@ -88,7 +88,7 @@ typedef enum ice_resolve_mode {
 int ice_parse_sdp(const char *sdp, ice_description_t *description);
 int ice_parse_candidate_sdp(const char *line, ice_candidate_t *candidate);
 int ice_create_local_description(ice_description_t *description);
-int ice_create_local_candidate(ice_candidate_type_t type, int component,
+int ice_create_local_candidate(ice_candidate_type_t type, int component, int index,
                                const addr_record_t *record, ice_candidate_t *candidate);
 int ice_resolve_candidate(ice_candidate_t *candidate, ice_resolve_mode_t mode);
 int ice_add_candidate(ice_candidate_t *candidate, ice_description_t *description);
@@ -104,6 +104,6 @@ int ice_update_candidate_pair(ice_candidate_pair_t *pair, bool is_controlling);
 
 int ice_candidates_count(const ice_description_t *description, ice_candidate_type_t type);
 
-uint32_t ice_compute_priority(ice_candidate_type_t type, int family, int component);
+uint32_t ice_compute_priority(ice_candidate_type_t type, int family, int component, int index);
 
 #endif


### PR DESCRIPTION
This PR makes candidate priority unique as required by [RFC 8445](https://datatracker.ietf.org/doc/html/rfc8445#section-5.1.2.1), as libjuice incorrectly computed the same priority for candidates with the same type and family.