### PR TITLE
Memory leak in server_do_destroy

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -241,6 +241,12 @@ void server_do_destroy(juice_server_t *server) {
 		free(prev);
 	}
 
+	server_turn_alloc_t *end = server->allocs + server->allocs_count;
+	for (server_turn_alloc_t *alloc = server->allocs; alloc < end; ++alloc) {
+		turn_destroy_map(&alloc->map);
+	}
+	free((void *)server->allocs);
+
 	free((void *)server->config.realm);
 	free(server);
 

--- a/src/server.c
+++ b/src/server.c
@@ -232,6 +232,12 @@ void server_do_destroy(juice_server_t *server) {
 	closesocket(server->sock);
 	mutex_destroy(&server->mutex);
 
+	server_turn_alloc_t *end = server->allocs + server->allocs_count;
+	for (server_turn_alloc_t *alloc = server->allocs; alloc < end; ++alloc) {
+		delete_allocation(alloc);
+	}
+	free((void *)server->allocs);
+
 	juice_credentials_list_t *node = server->credentials;
 	while (node) {
 		juice_credentials_list_t *prev = node;
@@ -240,12 +246,6 @@ void server_do_destroy(juice_server_t *server) {
 		free((void *)prev->credentials.password);
 		free(prev);
 	}
-
-	server_turn_alloc_t *end = server->allocs + server->allocs_count;
-	for (server_turn_alloc_t *alloc = server->allocs; alloc < end; ++alloc) {
-		turn_destroy_map(&alloc->map);
-	}
-	free((void *)server->allocs);
 
 	free((void *)server->config.realm);
 	free(server);


### PR DESCRIPTION
Looks like there is the memory leak in server cleanup. I've caught this on linux with valgrind and gcc's leak sanitizer.

Here is valgrind output:
```
$ valgrind --leak-check=full --track-origins=yes ./cmake-build-debug/tests 2> valgrind
...
$ cat valgrind
==20712== Memcheck, a memory error detector
==20712== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==20712== Using Valgrind-3.17.0 and LibVEX; rerun with -h for copyright info
==20712== Command: ./cmake-build-debug/tests
==20712== 
==20712== 
==20712== HEAP SUMMARY:
==20712==     in use at exit: 34,176 bytes in 7 blocks
==20712==   total heap usage: 349 allocs, 342 frees, 891,343 bytes allocated
==20712== 
==20712== 34,176 (22,400 direct, 11,776 indirect) bytes in 1 blocks are definitely lost in loss record 4 of 4
==20712==    at 0x48423AF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==20712==    by 0x486B2A8: server_create (server.c:198)
==20712==    by 0x486A412: juice_server_create (juice.c:174)
==20712==    by 0x10B6B9: test_server (server.c:75)
==20712==    by 0x10941B: main (main.c:96)
==20712== 
==20712== LEAK SUMMARY:
==20712==    definitely lost: 22,400 bytes in 1 blocks
==20712==    indirectly lost: 11,776 bytes in 6 blocks
==20712==      possibly lost: 0 bytes in 0 blocks
==20712==    still reachable: 0 bytes in 0 blocks
==20712==         suppressed: 0 bytes in 0 blocks
==20712== 
==20712== For lists of detected and suppressed errors, rerun with: -s
==20712== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```
And leak sanitizer:
```
$ cmake -DCMAKE_C_FLAGS="-fsanitize=leak" ..
...
$ cmake --build .
...
$ ./tests 2>sanitizer
...
$ cat sanitizer 

=================================================================
==22668==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 22400 byte(s) in 1 object(s) allocated from:
    #0 0x7f157cd4efe5  (/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/liblsan.so.0+0xefe5)
    #1 0x7f157cd2bbd8 in server_create /home/vollmond/scm/libjuice/src/server.c:198
    #2 0x7f157cd2ad42 in juice_server_create /home/vollmond/scm/libjuice/src/juice.c:174
    #3 0x5638271db6f9 in test_server /home/vollmond/scm/libjuice/test/server.c:75
    #4 0x5638271d945b in main /home/vollmond/scm/libjuice/test/main.c:96
    #5 0x7f157cb557ec in __libc_start_main (/lib64/libc.so.6+0x237ec)

Indirect leak of 10752 byte(s) in 2 object(s) allocated from:
    #0 0x7f157cd4efe5  (/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/liblsan.so.0+0xefe5)
    #1 0x7f157cd33e99 in turn_init_map /home/vollmond/scm/libjuice/src/turn.c:233
    #2 0x7f157cd2e2a9 in server_process_turn_allocate /home/vollmond/scm/libjuice/src/server.c:884
    #3 0x7f157cd2dae1 in server_dispatch_stun /home/vollmond/scm/libjuice/src/server.c:755
    #4 0x7f157cd2cec4 in server_input /home/vollmond/scm/libjuice/src/server.c:537
    #5 0x7f157cd2c983 in server_recv /home/vollmond/scm/libjuice/src/server.c:465
    #6 0x7f157cd2c5b5 in server_run /home/vollmond/scm/libjuice/src/server.c:403
    #7 0x7f157cd2b796 in server_thread_entry /home/vollmond/scm/libjuice/src/server.c:99
    #8 0x7f157ccfbdbd in start_thread (/lib64/libpthread.so.0+0x7dbd)

Indirect leak of 512 byte(s) in 2 object(s) allocated from:
    #0 0x7f157cd4efe5  (/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/liblsan.so.0+0xefe5)
    #1 0x7f157cd33eda in turn_init_map /home/vollmond/scm/libjuice/src/turn.c:235
    #2 0x7f157cd2e2a9 in server_process_turn_allocate /home/vollmond/scm/libjuice/src/server.c:884
    #3 0x7f157cd2dae1 in server_dispatch_stun /home/vollmond/scm/libjuice/src/server.c:755
    #4 0x7f157cd2cec4 in server_input /home/vollmond/scm/libjuice/src/server.c:537
    #5 0x7f157cd2c983 in server_recv /home/vollmond/scm/libjuice/src/server.c:465
    #6 0x7f157cd2c5b5 in server_run /home/vollmond/scm/libjuice/src/server.c:403
    #7 0x7f157cd2b796 in server_thread_entry /home/vollmond/scm/libjuice/src/server.c:99
    #8 0x7f157ccfbdbd in start_thread (/lib64/libpthread.so.0+0x7dbd)

Indirect leak of 512 byte(s) in 2 object(s) allocated from:
    #0 0x7f157cd4efe5  (/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/liblsan.so.0+0xefe5)
    #1 0x7f157cd33eb9 in turn_init_map /home/vollmond/scm/libjuice/src/turn.c:234
    #2 0x7f157cd2e2a9 in server_process_turn_allocate /home/vollmond/scm/libjuice/src/server.c:884
    #3 0x7f157cd2dae1 in server_dispatch_stun /home/vollmond/scm/libjuice/src/server.c:755
    #4 0x7f157cd2cec4 in server_input /home/vollmond/scm/libjuice/src/server.c:537
    #5 0x7f157cd2c983 in server_recv /home/vollmond/scm/libjuice/src/server.c:465
    #6 0x7f157cd2c5b5 in server_run /home/vollmond/scm/libjuice/src/server.c:403
    #7 0x7f157cd2b796 in server_thread_entry /home/vollmond/scm/libjuice/src/server.c:99
    #8 0x7f157ccfbdbd in start_thread (/lib64/libpthread.so.0+0x7dbd)

SUMMARY: LeakSanitizer: 34176 byte(s) leaked in 7 allocation(s).
```