### PR TITLE
Single-thread polling and UDP multiplexing support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,9 @@ set(LIBJUICE_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/agent.c
 	${CMAKE_CURRENT_SOURCE_DIR}/src/crc32.c
 	${CMAKE_CURRENT_SOURCE_DIR}/src/const_time.c
+	${CMAKE_CURRENT_SOURCE_DIR}/src/conn.c
+	${CMAKE_CURRENT_SOURCE_DIR}/src/conn_poll.c
+	${CMAKE_CURRENT_SOURCE_DIR}/src/conn_thread.c
 	${CMAKE_CURRENT_SOURCE_DIR}/src/base64.c
 	${CMAKE_CURRENT_SOURCE_DIR}/src/hash.c
 	${CMAKE_CURRENT_SOURCE_DIR}/src/hmac.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ set(LIBJUICE_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/conn.c
 	${CMAKE_CURRENT_SOURCE_DIR}/src/conn_poll.c
 	${CMAKE_CURRENT_SOURCE_DIR}/src/conn_thread.c
+	${CMAKE_CURRENT_SOURCE_DIR}/src/conn_mux.c
 	${CMAKE_CURRENT_SOURCE_DIR}/src/base64.c
 	${CMAKE_CURRENT_SOURCE_DIR}/src/hash.c
 	${CMAKE_CURRENT_SOURCE_DIR}/src/hmac.c

--- a/include/juice/juice.h
+++ b/include/juice/juice.h
@@ -156,6 +156,8 @@ typedef enum juice_concurrency_mode {
 	JUICE_CONCURRENCY_MODE_THREAD,   // Each connection runs in its own thread
 } juice_concurrency_mode_t;
 
+#define JUICE_CONCURRENCY_MODE_DEFAULT JUICE_CONCURRENCY_MODE_POLL
+
 JUICE_EXPORT void juice_set_concurrency_mode(juice_concurrency_mode_t mode);
 JUICE_EXPORT juice_concurrency_mode_t juice_get_concurrency_mode(void);
 

--- a/include/juice/juice.h
+++ b/include/juice/juice.h
@@ -151,12 +151,13 @@ JUICE_EXPORT int juice_server_add_credentials(juice_server_t *server,
 // Connection concurrency mode
 
 typedef enum juice_concurrency_mode {
-	JUICE_CONCURRENCY_MODE_POLL = 0,
-	JUICE_CONCURRENCY_MODE_THREAD,
-	JUICE_CONCURRENCY_MODE_MUX,
+	JUICE_CONCURRENCY_MODE_POLL = 0, // Connections share a single thread
+	JUICE_CONCURRENCY_MODE_MUX,      // Connections are multiplexed on a single UDP socket
+	JUICE_CONCURRENCY_MODE_THREAD,   // Each connection runs in its own thread
 } juice_concurrency_mode_t;
 
 JUICE_EXPORT void juice_set_concurrency_mode(juice_concurrency_mode_t mode);
+JUICE_EXPORT juice_concurrency_mode_t juice_get_concurrency_mode(void);
 
 // Logging
 

--- a/include/juice/juice.h
+++ b/include/juice/juice.h
@@ -53,7 +53,7 @@ extern "C" {
 typedef struct juice_agent juice_agent_t;
 
 typedef enum juice_state {
-	JUICE_STATE_DISCONNECTED,
+	JUICE_STATE_DISCONNECTED = 0,
 	JUICE_STATE_GATHERING,
 	JUICE_STATE_CONNECTING,
 	JUICE_STATE_CONNECTED,
@@ -148,10 +148,20 @@ JUICE_EXPORT int juice_server_add_credentials(juice_server_t *server,
                                               const juice_server_credentials_t *credentials,
                                               unsigned long lifetime_ms);
 
+// Connection concurrency mode
+
+typedef enum juice_concurrency_mode {
+	JUICE_CONCURRENCY_MODE_POLL = 0,
+	JUICE_CONCURRENCY_MODE_THREAD,
+	JUICE_CONCURRENCY_MODE_MUX,
+} juice_concurrency_mode_t;
+
+JUICE_EXPORT void juice_set_concurrency_mode(juice_concurrency_mode_t mode);
+
 // Logging
 
-typedef enum {
-	JUICE_LOG_LEVEL_VERBOSE,
+typedef enum juice_log_level {
+	JUICE_LOG_LEVEL_VERBOSE = 0,
 	JUICE_LOG_LEVEL_DEBUG,
 	JUICE_LOG_LEVEL_INFO,
 	JUICE_LOG_LEVEL_WARN,

--- a/include/juice/juice.h
+++ b/include/juice/juice.h
@@ -74,7 +74,15 @@ typedef struct juice_turn_server {
 	uint16_t port;
 } juice_turn_server_t;
 
+typedef enum juice_concurrency_mode {
+	JUICE_CONCURRENCY_MODE_POLL = 0, // Connections share a single thread
+	JUICE_CONCURRENCY_MODE_MUX,      // Connections are multiplexed on a single UDP socket
+	JUICE_CONCURRENCY_MODE_THREAD,   // Each connection runs in its own thread
+} juice_concurrency_mode_t;
+
 typedef struct juice_config {
+	juice_concurrency_mode_t concurrency_mode;
+
 	const char *stun_server_host;
 	uint16_t stun_server_port;
 
@@ -147,19 +155,6 @@ JUICE_EXPORT uint16_t juice_server_get_port(juice_server_t *server);
 JUICE_EXPORT int juice_server_add_credentials(juice_server_t *server,
                                               const juice_server_credentials_t *credentials,
                                               unsigned long lifetime_ms);
-
-// Connection concurrency mode
-
-typedef enum juice_concurrency_mode {
-	JUICE_CONCURRENCY_MODE_POLL = 0, // Connections share a single thread
-	JUICE_CONCURRENCY_MODE_MUX,      // Connections are multiplexed on a single UDP socket
-	JUICE_CONCURRENCY_MODE_THREAD,   // Each connection runs in its own thread
-} juice_concurrency_mode_t;
-
-#define JUICE_CONCURRENCY_MODE_DEFAULT JUICE_CONCURRENCY_MODE_POLL
-
-JUICE_EXPORT void juice_set_concurrency_mode(juice_concurrency_mode_t mode);
-JUICE_EXPORT juice_concurrency_mode_t juice_get_concurrency_mode(void);
 
 // Logging
 

--- a/src/agent.c
+++ b/src/agent.c
@@ -257,7 +257,7 @@ int agent_gather_candidates(juice_agent_t *agent) {
 	agent_change_state(agent, JUICE_STATE_CONNECTING);
 
 	// TURN server resolution
-	juice_concurrency_mode_t mode = juice_get_concurrency_mode();
+	juice_concurrency_mode_t mode = agent->config.concurrency_mode;
 	if (mode == JUICE_CONCURRENCY_MODE_MUX) {
 		if (agent->config.turn_servers_count > 0)
 			JLOG_WARN("TURN servers are not supported in mux mode");

--- a/src/agent.h
+++ b/src/agent.h
@@ -213,6 +213,8 @@ void agent_update_gathering_done(juice_agent_t *agent);
 void agent_update_candidate_pairs(juice_agent_t *agent);
 void agent_update_ordered_pairs(juice_agent_t *agent);
 
+agent_stun_entry_t *agent_find_entry_from_transaction_id(juice_agent_t *agent,
+                                                         const uint8_t *transaction_id);
 agent_stun_entry_t *
 agent_find_entry_from_record(juice_agent_t *agent, const addr_record_t *record,
                              const addr_record_t *relayed); // relayed may be NULL

--- a/src/conn.c
+++ b/src/conn.c
@@ -26,7 +26,7 @@
 #include <assert.h>
 #include <string.h>
 
-#define INITIAL_REGISTRY_SIZE 2
+#define INITIAL_REGISTRY_SIZE 16
 
 static atomic(juice_concurrency_mode_t) concurrency_mode = ATOMIC_VAR_INIT(JUICE_CONCURRENCY_MODE_DEFAULT);
 

--- a/src/conn.c
+++ b/src/conn.c
@@ -72,7 +72,7 @@ int conn_create(juice_agent_t *agent, udp_socket_config_t *config) {
 			mutex_unlock(&init_mutex);
 			return -1;
 		}
-		registry->agents = calloc(INITIAL_REGISTRY_SIZE, sizeof(juice_agent_t *));
+		registry->agents = malloc(INITIAL_REGISTRY_SIZE * sizeof(juice_agent_t *));
 		if (!registry->agents) {
 			JLOG_FATAL("Memory allocation failed for connections array");
 			mutex_unlock(&init_mutex);
@@ -80,6 +80,7 @@ int conn_create(juice_agent_t *agent, udp_socket_config_t *config) {
 		}
 		registry->agents_size = INITIAL_REGISTRY_SIZE;
 		registry->agents_count = 0;
+		memset(registry->agents, 0, INITIAL_REGISTRY_SIZE * sizeof(juice_agent_t *));
 
 		mutex_init(&registry->mutex, MUTEX_RECURSIVE);
 		mutex_lock(&registry->mutex);
@@ -117,7 +118,7 @@ int conn_create(juice_agent_t *agent, udp_socket_config_t *config) {
 
 		registry->agents = new_agents;
 		registry->agents_size = new_size;
-		memset(registry->agents + i, 0, (new_size - i) * sizeof(juice_agent_t));
+		memset(registry->agents + i, 0, (new_size - i) * sizeof(juice_agent_t *));
 	}
 
 	registry->agents[i] = agent;

--- a/src/conn.c
+++ b/src/conn.c
@@ -1,0 +1,207 @@
+/**
+ * Copyright (c) 2022 Paul-Louis Ageneau
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "conn.h"
+#include "agent.h"
+#include "conn_poll.h"
+#include "conn_thread.h"
+#include "log.h"
+
+#include <assert.h>
+#include <string.h>
+
+#define INITIAL_ENTRIES_SIZE 2
+
+static conn_registry_t *registry = NULL;
+static mutex_t init_mutex = MUTEX_INITIALIZER;
+static juice_concurrency_mode_t concurrency_mode = JUICE_CONCURRENCY_MODE_POLL;
+
+typedef struct conn_mode_entry  {
+	int (*init_func)(conn_registry_t *registry, udp_socket_config_t *config);
+	void (*cleanup_func)(conn_registry_t *registry);
+} conn_mode_entry_t;
+
+#define MODE_ENTRIES_SIZE 2
+
+static const conn_mode_entry_t mode_entries[MODE_ENTRIES_SIZE] = {
+	{conn_poll_registry_init, conn_poll_registry_cleanup},
+	{conn_thread_registry_init, conn_thread_registry_cleanup }
+};
+
+
+JUICE_EXPORT void juice_set_concurrency_mode(juice_concurrency_mode_t mode) {
+	mutex_lock(&init_mutex);
+	if(mode >= 0 && mode < MODE_ENTRIES_SIZE) {
+		concurrency_mode = mode;
+	} else {
+		JLOG_ERROR("Invalid concurrency mode");
+	}
+	mutex_unlock(&init_mutex);
+}
+
+int conn_create(juice_agent_t *agent, udp_socket_config_t *config) {
+	mutex_lock(&init_mutex);
+	JLOG_DEBUG("Creating connection");
+
+	if (!registry) {
+		JLOG_DEBUG("Creating connections registry");
+
+		registry = calloc(1, sizeof(conn_registry_t));
+		if (!registry) {
+			JLOG_FATAL("Memory allocation failed for connections registry");
+			mutex_unlock(&init_mutex);
+			return -1;
+		}
+		registry->agents = calloc(INITIAL_ENTRIES_SIZE, sizeof(juice_agent_t *));
+		if (!registry->agents) {
+			JLOG_FATAL("Memory allocation failed for connections array");
+			mutex_unlock(&init_mutex);
+			return -1;
+		}
+		registry->agents_size = INITIAL_ENTRIES_SIZE;
+		registry->agents_count = 0;
+
+		mutex_init(&registry->mutex, MUTEX_RECURSIVE);
+		mutex_lock(&registry->mutex);
+
+		registry->mode = concurrency_mode;
+		if (mode_entries[registry->mode].init_func(registry, config)) {
+			mutex_unlock(&registry->mutex);
+			mutex_unlock(&init_mutex);
+			return -1;
+		}
+
+	} else {
+		mutex_lock(&registry->mutex);
+	}
+	mutex_unlock(&init_mutex);
+
+	int i = 0;
+	while (i < registry->agents_size) {
+		if (!registry->agents[i])
+			break;
+
+		++i;
+	}
+
+	if (i == registry->agents_size) {
+		int new_size = registry->agents_size * 2;
+		JLOG_DEBUG("Reallocating connections array, new_size=%d", new_size);
+
+		juice_agent_t **new_agents = realloc(registry->agents, new_size * sizeof(juice_agent_t *));
+		if (!new_agents) {
+			JLOG_FATAL("Memory reallocation failed for connections array");
+			mutex_unlock(&registry->mutex);
+			return -1;
+		}
+
+		registry->agents = new_agents;
+		registry->agents_size = new_size;
+		memset(registry->agents + i, 0, (new_size - i) * sizeof(juice_agent_t));
+	}
+
+	registry->agents[i] = agent;
+	agent->conn_index = i;
+
+	if (registry->init_func(agent, registry, config)) {
+		mutex_unlock(&registry->mutex);
+		return -1;
+	}
+
+	++registry->agents_count;
+
+	mutex_unlock(&registry->mutex);
+	conn_interrupt(agent);
+	return 0;
+}
+
+void conn_destroy(juice_agent_t *agent) {
+	assert(registry);
+	mutex_lock(&init_mutex);
+	mutex_lock(&registry->mutex);
+	JLOG_DEBUG("Destroying connection");
+
+	registry->cleanup_func(agent);
+
+	int i = agent->conn_index;
+	assert(i >= 0 && i < registry->agents_size);
+	assert(registry->agents[i] == agent);
+	registry->agents[i] = NULL;
+	agent->conn_index = -1;
+
+	assert(registry->agents_count > 0);
+	if (--registry->agents_count == 0) {
+		JLOG_DEBUG("No connection left, destroying connections registry");
+		mutex_unlock(&registry->mutex);
+
+		mode_entries[registry->mode].cleanup_func(registry);
+		free(registry->agents);
+		free(registry);
+		registry = NULL;
+
+		mutex_unlock(&init_mutex);
+		return;
+	}
+
+	JLOG_VERBOSE("%d connection%s left", registry->agents_count,
+	             registry->agents_count >= 2 ? "s" : "");
+
+	mutex_unlock(&registry->mutex);
+	mutex_unlock(&init_mutex);
+}
+
+void conn_lock(juice_agent_t *agent) {
+	if (!agent->conn_impl)
+		return;
+
+	assert(registry);
+	mutex_lock(&registry->mutex);
+}
+
+void conn_unlock(juice_agent_t *agent) {
+	if (!agent->conn_impl)
+		return;
+
+	assert(registry);
+	mutex_unlock(&registry->mutex);
+}
+
+int conn_interrupt(juice_agent_t *agent) {
+	if (!agent->conn_impl)
+		return -1;
+
+	assert(registry);
+	return registry->interrupt_func(agent);
+}
+
+int conn_send(juice_agent_t *agent, const addr_record_t *dst, const char *data, size_t size,
+              int ds) {
+	if (!agent->conn_impl)
+		return -1;
+
+	assert(registry);
+	return registry->send_func(agent, dst, data, size, ds);
+}
+
+int conn_get_addrs(juice_agent_t *agent, addr_record_t *records, size_t size) {
+	if (!agent->conn_impl)
+		return -1;
+
+	assert(registry);
+	return registry->get_addrs_func(agent, records, size);
+}

--- a/src/conn.c
+++ b/src/conn.c
@@ -30,7 +30,7 @@
 
 static conn_registry_t *registry = NULL;
 static mutex_t init_mutex = MUTEX_INITIALIZER;
-static juice_concurrency_mode_t concurrency_mode = JUICE_CONCURRENCY_MODE_POLL;
+static juice_concurrency_mode_t concurrency_mode = JUICE_CONCURRENCY_MODE_DEFAULT;
 
 typedef struct conn_mode_entry  {
 	int (*init_func)(conn_registry_t *registry, udp_socket_config_t *config);

--- a/src/conn.h
+++ b/src/conn.h
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2022 Paul-Louis Ageneau
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef JUICE_CONN_H
+#define JUICE_CONN_H
+
+#include "addr.h"
+#include "juice.h"
+#include "thread.h"
+#include "timestamp.h"
+#include "udp.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct juice_agent juice_agent_t;
+
+typedef struct conn_registry {
+	juice_concurrency_mode_t mode;
+	void *impl;
+	mutex_t mutex;
+	juice_agent_t **agents;
+	int agents_size;
+	int agents_count;
+
+	int (*init_func)(juice_agent_t *agent, struct conn_registry *registry, udp_socket_config_t *config);
+	void (*cleanup_func)(juice_agent_t *agent);
+	int (*interrupt_func)(juice_agent_t *agent);
+	int (*send_func)(juice_agent_t *agent, const addr_record_t *dst, const char *data, size_t size,
+	                 int ds);
+	int (*get_addrs_func)(juice_agent_t *agent, addr_record_t *records, size_t size);
+} conn_registry_t;
+
+int conn_create(juice_agent_t *agent, udp_socket_config_t *config);
+void conn_destroy(juice_agent_t *agent);
+void conn_lock(juice_agent_t *agent);
+void conn_unlock(juice_agent_t *agent);
+int conn_interrupt(juice_agent_t *agent);
+int conn_send(juice_agent_t *agent, const addr_record_t *dst, const char *data, size_t size,
+              int ds);
+int conn_get_addrs(juice_agent_t *agent, addr_record_t *records, size_t size);
+
+#endif

--- a/src/conn.h
+++ b/src/conn.h
@@ -31,19 +31,11 @@
 typedef struct juice_agent juice_agent_t;
 
 typedef struct conn_registry {
-	juice_concurrency_mode_t mode;
 	void *impl;
 	mutex_t mutex;
 	juice_agent_t **agents;
 	int agents_size;
 	int agents_count;
-
-	int (*init_func)(juice_agent_t *agent, struct conn_registry *registry, udp_socket_config_t *config);
-	void (*cleanup_func)(juice_agent_t *agent);
-	int (*interrupt_func)(juice_agent_t *agent);
-	int (*send_func)(juice_agent_t *agent, const addr_record_t *dst, const char *data, size_t size,
-	                 int ds);
-	int (*get_addrs_func)(juice_agent_t *agent, addr_record_t *records, size_t size);
 } conn_registry_t;
 
 int conn_create(juice_agent_t *agent, udp_socket_config_t *config);

--- a/src/conn_mux.c
+++ b/src/conn_mux.c
@@ -28,7 +28,7 @@
 #include <string.h>
 
 #define BUFFER_SIZE 4096
-#define INITIAL_MAP_SIZE 2
+#define INITIAL_MAP_SIZE 16
 
 typedef enum map_entry_type {
 	MAP_ENTRY_TYPE_EMPTY = 0,

--- a/src/conn_mux.c
+++ b/src/conn_mux.c
@@ -1,0 +1,525 @@
+/**
+ * Copyright (c) 2022 Paul-Louis Ageneau
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "conn_mux.h"
+#include "agent.h"
+#include "log.h"
+#include "socket.h"
+#include "stun.h"
+#include "thread.h"
+#include "udp.h"
+
+#include <assert.h>
+#include <string.h>
+
+#define BUFFER_SIZE 4096
+#define INITIAL_MAP_SIZE 2
+
+typedef enum map_entry_type {
+	MAP_ENTRY_TYPE_EMPTY = 0,
+	MAP_ENTRY_TYPE_DELETED,
+	MAP_ENTRY_TYPE_FULL
+} map_entry_type_t;
+
+typedef struct map_entry {
+	map_entry_type_t type;
+	juice_agent_t *agent;
+	addr_record_t record;
+} map_entry_t;
+
+typedef struct registry_impl {
+	thread_t thread;
+	socket_t sock;
+	mutex_t send_mutex;
+	int send_ds;
+	map_entry_t *map;
+	int map_size;
+	int map_count;
+} registry_impl_t;
+
+typedef struct conn_impl {
+	conn_registry_t *registry;
+	timestamp_t next_timestamp;
+	bool finished;
+} conn_impl_t;
+
+static bool is_ready(const juice_agent_t *agent) {
+	if (!agent)
+		return false;
+
+	conn_impl_t *conn_impl = agent->conn_impl;
+	if (!conn_impl || conn_impl->finished)
+		return false;
+
+	return true;
+}
+
+static map_entry_t *find_map_entry(registry_impl_t *impl, const addr_record_t *record,
+                                   bool allow_deleted);
+static int insert_map_entry(registry_impl_t *impl, const addr_record_t *record,
+                            juice_agent_t *agent);
+static int remove_map_entries(registry_impl_t *impl, juice_agent_t *agent);
+static int grow_map(registry_impl_t *impl, int new_size);
+
+static map_entry_t *find_map_entry(registry_impl_t *impl, const addr_record_t *record,
+                                   bool allow_deleted) {
+	unsigned long key = addr_record_hash(record, false) % impl->map_size;
+	unsigned long pos = key;
+	while (true) {
+		map_entry_t *entry = impl->map + pos;
+		if (entry->type == MAP_ENTRY_TYPE_EMPTY ||
+		    addr_record_is_equal(&entry->record, record, true)) // compare ports
+			break;
+
+		if (entry->type == MAP_ENTRY_TYPE_DELETED && allow_deleted)
+			break;
+
+		pos = (pos + 1) % impl->map_size;
+		if (pos == key)
+			return NULL;
+	}
+	return impl->map + pos;
+}
+
+static int insert_map_entry(registry_impl_t *impl, const addr_record_t *record,
+                            juice_agent_t *agent) {
+
+	map_entry_t *entry = find_map_entry(impl, record, true); // allow deleted
+	if (!entry || (entry->type != MAP_ENTRY_TYPE_FULL && impl->map_count * 2 >= impl->map_size)) {
+		grow_map(impl, impl->map_size * 2);
+		return insert_map_entry(impl, record, agent);
+	}
+
+	if(entry->type == MAP_ENTRY_TYPE_EMPTY)
+		++impl->map_count;
+
+	entry->type = MAP_ENTRY_TYPE_FULL;
+	entry->agent = agent;
+	entry->record = *record;
+
+	JLOG_VERBOSE("Added map entry, count=%d", impl->map_count);
+	return 0;
+}
+
+static int remove_map_entries(registry_impl_t *impl, juice_agent_t *agent) {
+	int count = 0;
+	for (int i = 0; i < impl->map_size; ++i) {
+		map_entry_t *entry = impl->map + i;
+		if (entry->type == MAP_ENTRY_TYPE_FULL && entry->agent == agent) {
+			entry->type = MAP_ENTRY_TYPE_DELETED;
+			entry->agent = NULL;
+			++count;
+		}
+	}
+
+	assert(impl->map_count >= count);
+	impl->map_count -= count;
+
+	JLOG_VERBOSE("Removed %d map entries, count=%d", count, impl->map_count);
+	return 0;
+}
+
+static int grow_map(registry_impl_t *impl, int new_size) {
+	if (new_size <= impl->map_size)
+		return 0;
+
+	JLOG_DEBUG("Growing map, new_size=%d", new_size);
+
+	map_entry_t *new_map = calloc(1, new_size * sizeof(map_entry_t));
+	if (!new_map) {
+		JLOG_FATAL("Memory allocation failed for map");
+		return -1;
+	}
+
+	map_entry_t *old_map = impl->map;
+	int old_size = impl->map_size;
+	impl->map = new_map;
+	impl->map_size = new_size;
+	impl->map_count = 0;
+
+	for (int i = 0; i < old_size; ++i) {
+		map_entry_t *old_entry = old_map + i;
+		if (old_entry->type == MAP_ENTRY_TYPE_FULL)
+			insert_map_entry(impl, &old_entry->record, old_entry->agent);
+	}
+
+	free(old_map);
+	return 0;
+}
+
+int conn_mux_prepare(conn_registry_t *registry, struct pollfd *pfd, timestamp_t *next_timestamp);
+int conn_mux_process(conn_registry_t *registry, struct pollfd *pfd);
+int conn_mux_recv(conn_registry_t *registry, char *buffer, size_t size, addr_record_t *src);
+void conn_mux_fail(conn_registry_t *registry);
+int conn_mux_run(conn_registry_t *registry);
+
+static thread_return_t THREAD_CALL conn_mux_entry(void *arg) {
+	conn_registry_t *registry = (conn_registry_t *)arg;
+	conn_mux_run(registry);
+	return (thread_return_t)0;
+}
+
+int conn_mux_registry_init(conn_registry_t *registry, udp_socket_config_t *config) {
+	(void)config;
+
+	registry->init_func = conn_mux_init;
+	registry->cleanup_func = conn_mux_cleanup;
+	registry->interrupt_func = conn_mux_interrupt;
+	registry->send_func = conn_mux_send;
+	registry->get_addrs_func = conn_mux_get_addrs;
+
+	registry_impl_t *registry_impl = calloc(1, sizeof(registry_impl_t));
+	if (!registry_impl) {
+		JLOG_FATAL("Memory allocation failed for connections registry impl");
+		return -1;
+	}
+
+	registry_impl->map = calloc(INITIAL_MAP_SIZE, sizeof(map_entry_t));
+	if (!registry_impl->map) {
+		JLOG_FATAL("Memory allocation failed for map");
+		free(registry_impl);
+		return -1;
+	}
+	registry_impl->map_size = INITIAL_MAP_SIZE;
+	registry_impl->map_count = 0;
+
+	registry_impl->sock = udp_create_socket(config);
+	if (registry_impl->sock == INVALID_SOCKET) {
+		JLOG_FATAL("UDP socket creation failed");
+		free(registry_impl->map);
+		free(registry_impl);
+		return -1;
+	}
+
+	mutex_init(&registry_impl->send_mutex, 0);
+	registry->impl = registry_impl;
+
+	JLOG_VERBOSE("Starting connections thread");
+	int ret = thread_init(&registry_impl->thread, conn_mux_entry, registry);
+	if (ret) {
+		JLOG_FATAL("thread_create for connections failed, error=%d", ret);
+		mutex_destroy(&registry_impl->send_mutex);
+		closesocket(registry_impl->sock);
+		free(registry_impl->map);
+		free(registry_impl);
+		registry->impl = NULL;
+		return -1;
+	}
+
+	return 0;
+}
+
+void conn_mux_registry_cleanup(conn_registry_t *registry) {
+	registry_impl_t *registry_impl = registry->impl;
+
+	JLOG_VERBOSE("Waiting for connections thread");
+	thread_join(registry_impl->thread, NULL);
+
+	mutex_destroy(&registry_impl->send_mutex);
+	closesocket(registry_impl->sock);
+	free(registry_impl->map);
+	free(registry->impl);
+	registry->impl = NULL;
+}
+
+int conn_mux_prepare(conn_registry_t *registry, struct pollfd *pfd, timestamp_t *next_timestamp) {
+	timestamp_t now = current_timestamp();
+	*next_timestamp = now + 60000;
+
+	mutex_lock(&registry->mutex);
+	registry_impl_t *registry_impl = registry->impl;
+	pfd->fd = registry_impl->sock;
+	pfd->events = POLLIN;
+
+	for (int i = 0; i < registry->agents_size; ++i) {
+		juice_agent_t *agent = registry->agents[i];
+		if (is_ready(agent)) {
+			conn_impl_t *conn_impl = agent->conn_impl;
+			if (*next_timestamp > conn_impl->next_timestamp)
+				*next_timestamp = conn_impl->next_timestamp;
+		}
+	}
+
+	int count = registry->agents_count;
+	mutex_unlock(&registry->mutex);
+	return count;
+}
+
+static juice_agent_t *lookup_agent(conn_registry_t *registry, char *buf, size_t len,
+                                   const addr_record_t *src) {
+	registry_impl_t *registry_impl = registry->impl;
+
+	map_entry_t *entry = find_map_entry(registry_impl, src, false);
+	juice_agent_t *agent = entry && entry->type == MAP_ENTRY_TYPE_FULL ? entry->agent : NULL;
+	if (agent)
+		return agent;
+
+	if (!is_stun_datagram(buf, len)) {
+		JLOG_INFO("Got non-STUN message from unknown source address");
+		return NULL;
+	}
+
+	stun_message_t msg;
+	if (stun_read(buf, len, &msg) < 0) {
+		JLOG_ERROR("STUN message reading failed");
+		return NULL;
+	}
+
+	if (msg.msg_class == STUN_CLASS_REQUEST && msg.msg_method == STUN_METHOD_BINDING && msg.has_integrity) {
+		// Binding request from peer
+		char username[STUN_MAX_USERNAME_LEN];
+		strcpy(username, msg.credentials.username);
+		char *separator = strchr(username, ':');
+		if (!separator) {
+			JLOG_WARN("STUN username invalid, username=\"%s\"", username);
+			return NULL;
+		}
+		*separator = '\0';
+		const char *local_ufrag = username;
+		for (int i = 0; i < registry->agents_size; ++i) {
+			agent = registry->agents[i];
+			if (is_ready(agent)) {
+				if (strcmp(local_ufrag, agent->local.ice_ufrag) == 0) {
+					insert_map_entry(registry_impl, src, agent);
+					return agent;
+				}
+			}
+		}
+
+	} else {
+		if(!STUN_IS_RESPONSE(msg.msg_class)) {
+			JLOG_INFO("Got unexpected STUN message from unknown source address");
+			return NULL;
+		}
+
+		for (int i = 0; i < registry->agents_size; ++i) {
+			agent = registry->agents[i];
+			if (is_ready(agent)) {
+				if (agent_find_entry_from_transaction_id(agent, msg.transaction_id)) {
+					return agent;
+				}
+			}
+		}
+	}
+
+	return NULL;
+}
+
+int conn_mux_process(conn_registry_t *registry, struct pollfd *pfd) {
+	mutex_lock(&registry->mutex);
+
+	if (pfd->revents & POLLNVAL || pfd->revents & POLLERR) {
+		JLOG_ERROR("Error when polling socket");
+		conn_mux_fail(registry);
+		mutex_unlock(&registry->mutex);
+		return -1;
+	}
+
+	if (pfd->revents & POLLIN) {
+		char buffer[BUFFER_SIZE];
+		addr_record_t src;
+		int ret;
+		while ((ret = conn_mux_recv(registry, buffer, BUFFER_SIZE, &src)) > 0) {
+			juice_agent_t *agent = lookup_agent(registry, buffer, (size_t)ret, &src);
+			if (!agent || !is_ready(agent)) {
+				JLOG_WARN("Agent not found, dropping");
+				continue;
+			}
+
+			JLOG_VERBOSE("Found agent");
+			conn_impl_t *conn_impl = agent->conn_impl;
+			if (agent_conn_recv(agent, buffer, (size_t)ret, &src) != 0) {
+				JLOG_WARN("Agent recv failed");
+				conn_impl->finished = true;
+				continue;
+			}
+
+			conn_impl->next_timestamp = current_timestamp();
+		}
+
+		if (ret < 0) {
+			conn_mux_fail(registry);
+			mutex_unlock(&registry->mutex);
+			return -1;
+		}
+	}
+
+	for (int i = 0; i < registry->agents_size; ++i) {
+		juice_agent_t *agent = registry->agents[i];
+		if (is_ready(agent)) {
+			conn_impl_t *conn_impl = agent->conn_impl;
+			if (conn_impl->next_timestamp <= current_timestamp()) {
+				if (agent_conn_update(agent, &conn_impl->next_timestamp) != 0) {
+					JLOG_WARN("Agent update failed");
+					conn_impl->finished = true;
+					continue;
+				}
+			}
+		}
+	}
+
+	mutex_unlock(&registry->mutex);
+	return 0;
+}
+
+int conn_mux_recv(conn_registry_t *registry, char *buffer, size_t size, addr_record_t *src) {
+	JLOG_VERBOSE("Receiving datagram");
+	registry_impl_t *registry_impl = registry->impl;
+	int len;
+	while ((len = udp_recvfrom(registry_impl->sock, buffer, size, src)) == 0) {
+		// Empty datagram (used to interrupt)
+	}
+
+	if (len < 0) {
+		if (sockerrno == SEAGAIN || sockerrno == SEWOULDBLOCK) {
+			JLOG_VERBOSE("No more datagrams to receive");
+			return 0;
+		}
+		JLOG_ERROR("recvfrom failed, errno=%d", sockerrno);
+		return -1;
+	}
+
+	addr_unmap_inet6_v4mapped((struct sockaddr *)&src->addr, &src->len);
+	return len; // len > 0
+}
+
+void conn_mux_fail(conn_registry_t *registry) {
+	for (int i = 0; i < registry->agents_size; ++i) {
+		juice_agent_t *agent = registry->agents[i];
+		if (is_ready(agent)) {
+			conn_impl_t *conn_impl = agent->conn_impl;
+			agent_conn_fail(agent);
+			conn_impl->finished = true;
+		}
+	}
+}
+
+int conn_mux_run(conn_registry_t *registry) {
+	struct pollfd pfd[1];
+	timestamp_t next_timestamp;
+	while (conn_mux_prepare(registry, pfd, &next_timestamp) > 0) {
+		timediff_t timediff = next_timestamp - current_timestamp();
+		if (timediff < 0)
+			timediff = 0;
+
+		JLOG_VERBOSE("Entering poll for %d ms", (int)timediff);
+		int ret = poll(pfd, 1, (int)timediff);
+		JLOG_VERBOSE("Leaving poll");
+		if (ret < 0) {
+			if (sockerrno == SEINTR || sockerrno == SEAGAIN) {
+				JLOG_VERBOSE("poll interrupted");
+				continue;
+			} else {
+				JLOG_FATAL("poll failed, errno=%d", sockerrno);
+				break;
+			}
+		}
+
+		if (conn_mux_process(registry, pfd) < 0)
+			break;
+	}
+
+	JLOG_DEBUG("Leaving connections thread");
+	return 0;
+}
+
+int conn_mux_init(juice_agent_t *agent, conn_registry_t *registry, udp_socket_config_t *config) {
+	(void)config; // ignored, only the config from the first connection is used
+
+	conn_impl_t *conn_impl = calloc(1, sizeof(conn_impl_t));
+	if (!conn_impl) {
+		JLOG_FATAL("Memory allocation failed for connection impl");
+		return -1;
+	}
+
+	conn_impl->registry = registry;
+	agent->conn_impl = conn_impl;
+	return 0;
+}
+
+void conn_mux_cleanup(juice_agent_t *agent) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+	conn_registry_t *registry = conn_impl->registry;
+
+	mutex_lock(&registry->mutex);
+	registry_impl_t *registry_impl = registry->impl;
+	remove_map_entries(registry_impl, agent);
+	mutex_unlock(&registry->mutex);
+
+	conn_mux_interrupt(agent);
+
+	free(agent->conn_impl);
+	agent->conn_impl = NULL;
+}
+
+int conn_mux_send(juice_agent_t *agent, const addr_record_t *dst, const char *data, size_t size,
+                  int ds) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+	registry_impl_t *registry_impl = conn_impl->registry->impl;
+
+	mutex_lock(&registry_impl->send_mutex);
+
+	if (registry_impl->send_ds >= 0 && registry_impl->send_ds != ds) {
+		JLOG_VERBOSE("Setting Differentiated Services field to 0x%X", ds);
+		if (udp_set_diffserv(registry_impl->sock, ds) == 0)
+			registry_impl->send_ds = ds;
+		else
+			registry_impl->send_ds = -1; // disable for next time
+	}
+
+	JLOG_VERBOSE("Sending datagram, size=%d", size);
+
+	int ret = udp_sendto(registry_impl->sock, data, size, dst);
+	if (ret < 0) {
+		if (sockerrno == SEAGAIN || sockerrno == SEWOULDBLOCK)
+			JLOG_INFO("Send failed, buffer is full");
+		else
+			JLOG_WARN("Send failed, errno=%d", sockerrno);
+	}
+
+	mutex_unlock(&registry_impl->send_mutex);
+	return ret;
+}
+
+int conn_mux_get_addrs(juice_agent_t *agent, addr_record_t *records, size_t size) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+	registry_impl_t *registry_impl = conn_impl->registry->impl;
+
+	return udp_get_addrs(registry_impl->sock, records, size);
+}
+
+int conn_mux_interrupt(juice_agent_t *agent) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+	conn_registry_t *registry = conn_impl->registry;
+
+	mutex_lock(&registry->mutex);
+	conn_impl->next_timestamp = current_timestamp();
+	mutex_unlock(&registry->mutex);
+
+	registry_impl_t *registry_impl = registry->impl;
+	mutex_lock(&registry_impl->send_mutex);
+	if (udp_sendto_self(registry_impl->sock, NULL, 0) < 0) {
+		if (sockerrno != SEAGAIN && sockerrno != SEWOULDBLOCK) {
+			JLOG_WARN("Failed to interrupt poll by triggering socket, errno=%d", sockerrno);
+		}
+		mutex_unlock(&registry_impl->send_mutex);
+		return -1;
+	}
+	mutex_unlock(&registry_impl->send_mutex);
+	return 0;
+}

--- a/src/conn_mux.h
+++ b/src/conn_mux.h
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2022 Paul-Louis Ageneau
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef JUICE_CONN_MUX_H
+#define JUICE_CONN_MUX_H
+
+#include "addr.h"
+#include "conn.h"
+#include "thread.h"
+#include "timestamp.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+int conn_mux_registry_init(conn_registry_t *registry, udp_socket_config_t *config);
+void conn_mux_registry_cleanup(conn_registry_t *registry);
+
+int conn_mux_init(juice_agent_t *agent, conn_registry_t *registry, udp_socket_config_t *config);
+void conn_mux_cleanup(juice_agent_t *agent);
+void conn_mux_lock(juice_agent_t *agent);
+void conn_mux_unlock(juice_agent_t *agent);
+int conn_mux_interrupt(juice_agent_t *agent);
+int conn_mux_send(juice_agent_t *agent, const addr_record_t *dst, const char *data, size_t size,
+                        int ds);
+int conn_mux_get_addrs(juice_agent_t *agent, addr_record_t *records, size_t size);
+
+#endif

--- a/src/conn_poll.c
+++ b/src/conn_poll.c
@@ -1,0 +1,362 @@
+/**
+ * Copyright (c) 2022 Paul-Louis Ageneau
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "conn_poll.h"
+#include "agent.h"
+#include "log.h"
+#include "socket.h"
+#include "thread.h"
+#include "udp.h"
+
+#include <assert.h>
+#include <string.h>
+
+#define BUFFER_SIZE 4096
+
+typedef struct registry_impl {
+	thread_t thread;
+} registry_impl_t;
+
+typedef enum conn_state { CONN_STATE_NEW = 0, CONN_STATE_READY, CONN_STATE_FINISHED } conn_state_t;
+
+typedef struct conn_impl {
+	conn_registry_t *registry;
+	conn_state_t state;
+	socket_t sock;
+	mutex_t send_mutex;
+	int send_ds;
+	timestamp_t next_timestamp;
+} conn_impl_t;
+
+typedef struct pfds_record {
+	struct pollfd *pfds;
+	nfds_t size;
+} pfds_record_t;
+
+int conn_poll_prepare(conn_registry_t *registry, pfds_record_t *pfds, timestamp_t *next_timestamp);
+int conn_poll_process(conn_registry_t *registry, pfds_record_t *pfds);
+int conn_poll_recv(socket_t sock, char *buffer, size_t size, addr_record_t *src);
+int conn_poll_run(conn_registry_t *registry);
+
+static thread_return_t THREAD_CALL conn_thread_entry(void *arg) {
+	conn_registry_t *registry = (conn_registry_t *)arg;
+	conn_poll_run(registry);
+	return (thread_return_t)0;
+}
+
+int conn_poll_registry_init(conn_registry_t *registry, udp_socket_config_t *config) {
+	(void)config;
+
+	registry->init_func = conn_poll_init;
+	registry->cleanup_func = conn_poll_cleanup;
+	registry->interrupt_func = conn_poll_interrupt;
+	registry->send_func = conn_poll_send;
+	registry->get_addrs_func = conn_poll_get_addrs;
+
+	registry_impl_t *registry_impl = calloc(1, sizeof(registry_impl_t));
+	if (!registry_impl) {
+		JLOG_FATAL("Memory allocation failed for connections registry impl");
+	}
+	registry->impl = registry_impl;
+
+	JLOG_VERBOSE("Starting connections thread");
+	int ret = thread_init(&registry_impl->thread, conn_thread_entry, registry);
+	if (ret) {
+		JLOG_FATAL("thread_create for connections failed, error=%d", ret);
+		free(registry_impl);
+		return -1;
+	}
+
+	return 0;
+}
+
+void conn_poll_registry_cleanup(conn_registry_t *registry) {
+	registry_impl_t *registry_impl = registry->impl;
+
+	JLOG_VERBOSE("Waiting for connections thread");
+	thread_join(registry_impl->thread, NULL);
+
+	free(registry->impl);
+	registry->impl = NULL;
+}
+
+int conn_poll_prepare(conn_registry_t *registry, pfds_record_t *pfds, timestamp_t *next_timestamp) {
+	timestamp_t now = current_timestamp();
+	*next_timestamp = now + 60000;
+
+	mutex_lock(&registry->mutex);
+	if (pfds->size != (nfds_t)registry->agents_size) {
+		struct pollfd *new_pfds =
+		    realloc(pfds->pfds, sizeof(struct pollfd) * registry->agents_size);
+		if (!new_pfds) {
+			JLOG_ERROR("Memory allocation for poll file descriptors failed");
+			goto error;
+		}
+		pfds->pfds = new_pfds;
+		pfds->size = (nfds_t)registry->agents_size;
+	}
+
+	for (nfds_t i = 0; i < pfds->size; ++i) {
+		struct pollfd *pfd = pfds->pfds + i;
+		juice_agent_t *agent = registry->agents[i];
+		if (!agent)
+			continue;
+
+		conn_impl_t *conn_impl = agent->conn_impl;
+		if (!conn_impl ||
+		    (conn_impl->state != CONN_STATE_NEW && conn_impl->state != CONN_STATE_READY)) {
+			pfd->fd = INVALID_SOCKET;
+			pfd->events = 0;
+			continue;
+		}
+
+		if (conn_impl->state == CONN_STATE_NEW)
+			conn_impl->state = CONN_STATE_READY;
+
+		if (*next_timestamp > conn_impl->next_timestamp)
+			*next_timestamp = conn_impl->next_timestamp;
+
+		pfd->fd = conn_impl->sock;
+		pfd->events = POLLIN;
+	}
+
+	int count = registry->agents_count;
+	mutex_unlock(&registry->mutex);
+	return count;
+
+error:
+	mutex_unlock(&registry->mutex);
+	return -1;
+}
+
+int conn_poll_recv(socket_t sock, char *buffer, size_t size, addr_record_t *src) {
+	JLOG_VERBOSE("Receiving datagram");
+	int len;
+	while ((len = udp_recvfrom(sock, buffer, size, src)) == 0) {
+		// Empty datagram (used to interrupt)
+	}
+
+	if (len < 0) {
+		if (sockerrno == SEAGAIN || sockerrno == SEWOULDBLOCK) {
+			JLOG_VERBOSE("No more datagrams to receive");
+			return 0;
+		}
+		JLOG_ERROR("recvfrom failed, errno=%d", sockerrno);
+		return -1;
+	}
+
+	addr_unmap_inet6_v4mapped((struct sockaddr *)&src->addr, &src->len);
+	return len; // len > 0
+}
+
+int conn_poll_process(conn_registry_t *registry, pfds_record_t *pfds) {
+	for (nfds_t i = 0; i < pfds->size; ++i) {
+		struct pollfd *pfd = pfds->pfds + i;
+		if (pfd->fd == INVALID_SOCKET)
+			continue;
+
+		mutex_lock(&registry->mutex);
+		juice_agent_t *agent = registry->agents[i];
+		if (!agent)
+			goto end;
+
+		conn_impl_t *conn_impl = agent->conn_impl;
+		if (!conn_impl || conn_impl->sock != pfd->fd || conn_impl->state != CONN_STATE_READY)
+			goto end;
+
+		if (pfd->revents & POLLNVAL || pfd->revents & POLLERR) {
+			JLOG_WARN("Error when polling socket");
+			agent_conn_fail(agent);
+			conn_impl->state = CONN_STATE_FINISHED;
+			goto end;
+		}
+
+		if (pfd->revents & POLLIN) {
+			char buffer[BUFFER_SIZE];
+			addr_record_t src;
+			int ret;
+			int left = 1000; // limit for fairness between sockets
+			while (left-- &&
+			       (ret = conn_poll_recv(conn_impl->sock, buffer, BUFFER_SIZE, &src)) > 0) {
+				if (agent_conn_recv(agent, buffer, (size_t)ret, &src) != 0) {
+					JLOG_WARN("Agent recv failed");
+					conn_impl->state = CONN_STATE_FINISHED;
+					break;
+				}
+			}
+			if (conn_impl->state == CONN_STATE_FINISHED)
+				goto end;
+
+			if (ret < 0) {
+				agent_conn_fail(agent);
+				conn_impl->state = CONN_STATE_FINISHED;
+				goto end;
+			}
+
+			if (agent_conn_update(agent, &conn_impl->next_timestamp) != 0) {
+				JLOG_WARN("Agent update failed");
+				conn_impl->state = CONN_STATE_FINISHED;
+				goto end;
+			}
+
+		} else if (conn_impl->next_timestamp <= current_timestamp()) {
+			if (agent_conn_update(agent, &conn_impl->next_timestamp) != 0) {
+				JLOG_WARN("Agent update failed");
+				conn_impl->state = CONN_STATE_FINISHED;
+				goto end;
+			}
+		}
+
+	end:
+		mutex_unlock(&registry->mutex);
+	}
+
+	return 0;
+}
+
+int conn_poll_run(conn_registry_t *registry) {
+	pfds_record_t pfds;
+	pfds.pfds = NULL;
+	pfds.size = 0;
+	timestamp_t next_timestamp = 0;
+	int count;
+	while ((count = conn_poll_prepare(registry, &pfds, &next_timestamp)) > 0) {
+		timediff_t timediff = next_timestamp - current_timestamp();
+		if (timediff < 0)
+			timediff = 0;
+
+		JLOG_VERBOSE("Entering poll on %d sockets for %d ms", count, (int)timediff);
+		int ret = poll(pfds.pfds, pfds.size, (int)timediff);
+		JLOG_VERBOSE("Leaving poll");
+		if (ret < 0) {
+			if (sockerrno == SEINTR || sockerrno == SEAGAIN) {
+				JLOG_VERBOSE("poll interrupted");
+				continue;
+			} else {
+				JLOG_FATAL("poll failed, errno=%d", sockerrno);
+				break;
+			}
+		}
+
+		if (conn_poll_process(registry, &pfds) < 0)
+			break;
+	}
+
+	JLOG_DEBUG("Leaving connections thread");
+	free(pfds.pfds);
+	return 0;
+}
+
+int conn_poll_init(juice_agent_t *agent, conn_registry_t *registry, udp_socket_config_t *config) {
+	conn_impl_t *conn_impl = calloc(1, sizeof(conn_impl_t));
+	if (!conn_impl) {
+		JLOG_FATAL("Memory allocation failed for connection impl");
+		return -1;
+	}
+
+	conn_impl->sock = udp_create_socket(config);
+	if (conn_impl->sock == INVALID_SOCKET) {
+		JLOG_ERROR("UDP socket creation failed");
+		return -1;
+	}
+
+	mutex_init(&conn_impl->send_mutex, 0);
+	conn_impl->registry = registry;
+
+	agent->conn_impl = conn_impl;
+	return 0;
+}
+
+void conn_poll_cleanup(juice_agent_t *agent) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+
+	conn_poll_interrupt(agent);
+
+	mutex_destroy(&conn_impl->send_mutex);
+	closesocket(conn_impl->sock);
+	free(agent->conn_impl);
+	agent->conn_impl = NULL;
+}
+
+int conn_poll_send(juice_agent_t *agent, const addr_record_t *dst, const char *data, size_t size,
+                   int ds) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+
+	mutex_lock(&conn_impl->send_mutex);
+
+	if (conn_impl->send_ds >= 0 && conn_impl->send_ds != ds) {
+		JLOG_VERBOSE("Setting Differentiated Services field to 0x%X", ds);
+		if (udp_set_diffserv(conn_impl->sock, ds) == 0)
+			conn_impl->send_ds = ds;
+		else
+			conn_impl->send_ds = -1; // disable for next time
+	}
+
+	JLOG_VERBOSE("Sending datagram, size=%d", size);
+
+	int ret = udp_sendto(conn_impl->sock, data, size, dst);
+	if (ret < 0) {
+		if (sockerrno == SEAGAIN || sockerrno == SEWOULDBLOCK)
+			JLOG_INFO("Send failed, buffer is full");
+		else
+			JLOG_WARN("Send failed, errno=%d", sockerrno);
+	}
+
+	mutex_unlock(&conn_impl->send_mutex);
+	return ret;
+}
+
+int conn_poll_get_addrs(juice_agent_t *agent, addr_record_t *records, size_t size) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+
+	return udp_get_addrs(conn_impl->sock, records, size);
+}
+
+int conn_poll_interrupt(juice_agent_t *agent) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+	conn_registry_t *registry = conn_impl->registry;
+
+	mutex_lock(&registry->mutex);
+	conn_impl->next_timestamp = current_timestamp();
+
+	for (int i = 0; i < registry->agents_size; ++i) {
+		juice_agent_t *agent = registry->agents[i];
+		if (!agent)
+			continue;
+
+		conn_impl_t *conn_impl = agent->conn_impl;
+		if (!conn_impl || conn_impl->state != CONN_STATE_READY)
+			continue;
+
+		mutex_lock(&conn_impl->send_mutex);
+		if (udp_sendto_self(conn_impl->sock, NULL, 0) < 0) {
+			if (sockerrno != SEAGAIN && sockerrno != SEWOULDBLOCK) {
+				JLOG_WARN("Failed to interrupt poll by triggering socket, errno=%d", sockerrno);
+			}
+			mutex_unlock(&conn_impl->send_mutex);
+			continue;
+		}
+
+		mutex_unlock(&conn_impl->send_mutex);
+		mutex_unlock(&registry->mutex);
+		return 0;
+	}
+
+	mutex_unlock(&registry->mutex);
+	return -1;
+}

--- a/src/conn_poll.c
+++ b/src/conn_poll.c
@@ -99,7 +99,7 @@ int conn_poll_registry_init(conn_registry_t *registry, udp_socket_config_t *conf
 
 	registry->impl = registry_impl;
 
-	JLOG_VERBOSE("Starting connections thread");
+	JLOG_DEBUG("Starting connections thread");
 	int ret = thread_init(&registry_impl->thread, conn_thread_entry, registry);
 	if (ret) {
 		JLOG_FATAL("thread_create for connections failed, error=%d", ret);
@@ -261,7 +261,7 @@ int conn_poll_process(conn_registry_t *registry, pfds_record_t *pfds) {
 			while (left-- &&
 			       (ret = conn_poll_recv(conn_impl->sock, buffer, BUFFER_SIZE, &src)) > 0) {
 				if (agent_conn_recv(agent, buffer, (size_t)ret, &src) != 0) {
-					JLOG_WARN("Agent recv failed");
+					JLOG_WARN("Agent receive failed");
 					conn_impl->state = CONN_STATE_FINISHED;
 					break;
 				}

--- a/src/conn_poll.h
+++ b/src/conn_poll.h
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2022 Paul-Louis Ageneau
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef JUICE_CONN_POLL_H
+#define JUICE_CONN_POLL_H
+
+#include "addr.h"
+#include "conn.h"
+#include "thread.h"
+#include "timestamp.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+int conn_poll_registry_init(conn_registry_t *registry, udp_socket_config_t *config);
+void conn_poll_registry_cleanup(conn_registry_t *registry);
+
+int conn_poll_init(juice_agent_t *agent, conn_registry_t *registry, udp_socket_config_t *config);
+void conn_poll_cleanup(juice_agent_t *agent);
+void conn_poll_lock(juice_agent_t *agent);
+void conn_poll_unlock(juice_agent_t *agent);
+int conn_poll_interrupt(juice_agent_t *agent);
+int conn_poll_send(juice_agent_t *agent, const addr_record_t *dst, const char *data, size_t size,
+                        int ds);
+int conn_poll_get_addrs(juice_agent_t *agent, addr_record_t *records, size_t size);
+
+#endif

--- a/src/conn_thread.c
+++ b/src/conn_thread.c
@@ -1,0 +1,291 @@
+/**
+ * Copyright (c) 2022 Paul-Louis Ageneau
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "conn_thread.h"
+#include "agent.h"
+#include "log.h"
+#include "socket.h"
+#include "thread.h"
+#include "udp.h"
+
+#include <assert.h>
+#include <string.h>
+
+#define BUFFER_SIZE 4096
+
+typedef struct conn_impl {
+	thread_t thread;
+	socket_t sock;
+	mutex_t mutex;
+	mutex_t send_mutex;
+	int send_ds;
+	timestamp_t next_timestamp;
+	bool stopped;
+} conn_impl_t;
+
+int conn_thread_run(juice_agent_t *agent);
+int conn_thread_prepare(juice_agent_t *agent, struct pollfd *pfd, timestamp_t *next_timestamp);
+int conn_thread_process(juice_agent_t *agent, struct pollfd *pfd);
+int conn_thread_recv(socket_t sock, char *buffer, size_t size, addr_record_t *src);
+
+static thread_return_t THREAD_CALL conn_thread_entry(void *arg) {
+	juice_agent_t *agent = (juice_agent_t *)arg;
+	conn_thread_run(agent);
+	return (thread_return_t)0;
+}
+
+int conn_thread_registry_init(conn_registry_t *registry, udp_socket_config_t *config) {
+	(void)config;
+
+	registry->init_func = conn_thread_init;
+	registry->cleanup_func = conn_thread_cleanup;
+	registry->interrupt_func = conn_thread_interrupt;
+	registry->send_func = conn_thread_send;
+	registry->get_addrs_func = conn_thread_get_addrs;
+
+	registry->impl = NULL; // Unused
+
+	return 0;
+}
+
+void conn_thread_registry_cleanup(conn_registry_t *registry) {
+	(void)registry;
+	// Nothing to do
+}
+
+int conn_thread_prepare(juice_agent_t *agent, struct pollfd *pfd, timestamp_t *next_timestamp) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+	mutex_lock(&conn_impl->mutex);
+	if (conn_impl->stopped) {
+		mutex_unlock(&conn_impl->mutex);
+		return 0;
+	}
+
+	pfd->fd = conn_impl->sock;
+	pfd->events = POLLIN;
+
+	*next_timestamp = conn_impl->next_timestamp;
+
+	mutex_unlock(&conn_impl->mutex);
+	return 1;
+}
+
+int conn_thread_process(juice_agent_t *agent, struct pollfd *pfd) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+	mutex_lock(&conn_impl->mutex);
+	if (conn_impl->stopped) {
+		mutex_unlock(&conn_impl->mutex);
+		return -1;
+	}
+
+	if (pfd->revents & POLLNVAL || pfd->revents & POLLERR) {
+		JLOG_ERROR("Error when polling socket");
+		agent_conn_fail(agent);
+		mutex_unlock(&conn_impl->mutex);
+		return -1;
+	}
+
+	if (pfd->revents & POLLIN) {
+		char buffer[BUFFER_SIZE];
+		addr_record_t src;
+		int ret;
+		while ((ret = conn_thread_recv(conn_impl->sock, buffer, BUFFER_SIZE, &src)) > 0) {
+			if (agent_conn_recv(agent, buffer, (size_t)ret, &src) != 0) {
+				JLOG_WARN("Agent recv failed");
+				mutex_unlock(&conn_impl->mutex);
+				return -1;
+			}
+		}
+
+		if (ret < 0) {
+			agent_conn_fail(agent);
+			mutex_unlock(&conn_impl->mutex);
+			return -1;
+		}
+
+		if (agent_conn_update(agent, &conn_impl->next_timestamp) != 0) {
+			JLOG_WARN("Agent update failed");
+			mutex_unlock(&conn_impl->mutex);
+			return -1;
+		}
+
+	} else if (conn_impl->next_timestamp <= current_timestamp()) {
+		if (agent_conn_update(agent, &conn_impl->next_timestamp) != 0) {
+			JLOG_WARN("Agent update failed");
+			mutex_unlock(&conn_impl->mutex);
+			return -1;
+		}
+	}
+
+	mutex_unlock(&conn_impl->mutex);
+	return 0;
+}
+
+int conn_thread_recv(socket_t sock, char *buffer, size_t size, addr_record_t *src) {
+	JLOG_VERBOSE("Receiving datagram");
+	int len;
+	while ((len = udp_recvfrom(sock, buffer, size, src)) == 0) {
+		// Empty datagram (used to interrupt)
+	}
+
+	if (len < 0) {
+		if (sockerrno == SEAGAIN || sockerrno == SEWOULDBLOCK) {
+			JLOG_VERBOSE("No more datagrams to receive");
+			return 0;
+		}
+		JLOG_ERROR("recvfrom failed, errno=%d", sockerrno);
+		return -1;
+	}
+
+	addr_unmap_inet6_v4mapped((struct sockaddr *)&src->addr, &src->len);
+	return len; // len > 0
+}
+
+int conn_thread_run(juice_agent_t *agent) {
+	struct pollfd pfd[1];
+	timestamp_t next_timestamp;
+	while (conn_thread_prepare(agent, pfd, &next_timestamp) > 0) {
+		timediff_t timediff = next_timestamp - current_timestamp();
+		if (timediff < 0)
+			timediff = 0;
+
+		JLOG_VERBOSE("Entering poll for %d ms", (int)timediff);
+		int ret = poll(pfd, 1, (int)timediff);
+		JLOG_VERBOSE("Leaving poll");
+		if (ret < 0) {
+			if (sockerrno == SEINTR || sockerrno == SEAGAIN) {
+				JLOG_VERBOSE("poll interrupted");
+				continue;
+			} else {
+				JLOG_FATAL("poll failed, errno=%d", sockerrno);
+				break;
+			}
+		}
+
+		if (conn_thread_process(agent, pfd) < 0)
+			break;
+	}
+
+	JLOG_DEBUG("Leaving connection thread");
+	return 0;
+}
+
+int conn_thread_init(juice_agent_t *agent, conn_registry_t *registry, udp_socket_config_t *config) {
+	(void)registry;
+
+	conn_impl_t *conn_impl = calloc(1, sizeof(conn_impl_t));
+	if (!conn_impl) {
+		JLOG_FATAL("Memory allocation failed for connection impl");
+		return -1;
+	}
+
+	conn_impl->sock = udp_create_socket(config);
+	if (conn_impl->sock == INVALID_SOCKET) {
+		JLOG_ERROR("UDP socket creation failed");
+		return -1;
+	}
+
+	mutex_init(&conn_impl->mutex, 0);
+	mutex_init(&conn_impl->send_mutex, 0);
+
+	agent->conn_impl = conn_impl;
+
+	JLOG_VERBOSE("Starting connection thread");
+	int ret = thread_init(&conn_impl->thread, conn_thread_entry, agent);
+	if (ret) {
+		JLOG_FATAL("thread_create for connection failed, error=%d", ret);
+		free(conn_impl);
+		agent->conn_impl = NULL;
+		return -1;
+	}
+
+	return 0;
+}
+
+void conn_thread_cleanup(juice_agent_t *agent) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+
+	mutex_lock(&conn_impl->mutex);
+	conn_impl->stopped = true;
+	mutex_unlock(&conn_impl->mutex);
+
+	conn_thread_interrupt(agent);
+
+	JLOG_VERBOSE("Waiting for connection thread");
+	thread_join(conn_impl->thread, NULL);
+
+	closesocket(conn_impl->sock);
+	mutex_destroy(&conn_impl->mutex);
+	mutex_destroy(&conn_impl->send_mutex);
+	free(agent->conn_impl);
+	agent->conn_impl = NULL;
+}
+
+int conn_thread_send(juice_agent_t *agent, const addr_record_t *dst, const char *data, size_t size,
+                     int ds) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+
+	mutex_lock(&conn_impl->send_mutex);
+
+	if (conn_impl->send_ds >= 0 && conn_impl->send_ds != ds) {
+		JLOG_VERBOSE("Setting Differentiated Services field to 0x%X", ds);
+		if (udp_set_diffserv(conn_impl->sock, ds) == 0)
+			conn_impl->send_ds = ds;
+		else
+			conn_impl->send_ds = -1; // disable for next time
+	}
+
+	JLOG_VERBOSE("Sending datagram, size=%d", size);
+
+	int ret = udp_sendto(conn_impl->sock, data, size, dst);
+	if (ret < 0) {
+		if (sockerrno == SEAGAIN || sockerrno == SEWOULDBLOCK)
+			JLOG_INFO("Send failed, buffer is full");
+		else
+			JLOG_WARN("Send failed, errno=%d", sockerrno);
+	}
+
+	mutex_unlock(&conn_impl->send_mutex);
+	return ret;
+}
+
+int conn_thread_get_addrs(juice_agent_t *agent, addr_record_t *records, size_t size) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+
+	return udp_get_addrs(conn_impl->sock, records, size);
+}
+
+int conn_thread_interrupt(juice_agent_t *agent) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+
+	mutex_lock(&conn_impl->mutex);
+	conn_impl->next_timestamp = current_timestamp();
+	mutex_unlock(&conn_impl->mutex);
+
+	mutex_lock(&conn_impl->send_mutex);
+	if (udp_sendto_self(conn_impl->sock, NULL, 0) < 0) {
+		if (sockerrno != SEAGAIN && sockerrno != SEWOULDBLOCK) {
+			JLOG_WARN("Failed to interrupt poll by triggering socket, errno=%d", sockerrno);
+		}
+		mutex_unlock(&conn_impl->send_mutex);
+		return -1;
+	}
+
+	mutex_unlock(&conn_impl->send_mutex);
+	return 0;
+}

--- a/src/conn_thread.c
+++ b/src/conn_thread.c
@@ -98,7 +98,7 @@ int conn_thread_process(juice_agent_t *agent, struct pollfd *pfd) {
 		int ret;
 		while ((ret = conn_thread_recv(conn_impl->sock, buffer, BUFFER_SIZE, &src)) > 0) {
 			if (agent_conn_recv(agent, buffer, (size_t)ret, &src) != 0) {
-				JLOG_WARN("Agent recv failed");
+				JLOG_WARN("Agent receive failed");
 				mutex_unlock(&conn_impl->mutex);
 				return -1;
 			}
@@ -197,7 +197,7 @@ int conn_thread_init(juice_agent_t *agent, conn_registry_t *registry, udp_socket
 
 	agent->conn_impl = conn_impl;
 
-	JLOG_VERBOSE("Starting connection thread");
+	JLOG_DEBUG("Starting connection thread");
 	int ret = thread_init(&conn_impl->thread, conn_thread_entry, agent);
 	if (ret) {
 		JLOG_FATAL("thread_create for connection failed, error=%d", ret);

--- a/src/conn_thread.h
+++ b/src/conn_thread.h
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2022 Paul-Louis Ageneau
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef JUICE_CONN_THREAD_H
+#define JUICE_CONN_THREAD_H
+
+#include "addr.h"
+#include "conn.h"
+#include "thread.h"
+#include "timestamp.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+int conn_thread_registry_init(conn_registry_t *registry, udp_socket_config_t *config);
+void conn_thread_registry_cleanup(conn_registry_t *registry);
+
+int conn_thread_init(juice_agent_t *agent, conn_registry_t *registry, udp_socket_config_t *config);
+void conn_thread_cleanup(juice_agent_t *agent);
+void conn_thread_lock(juice_agent_t *agent);
+void conn_thread_unlock(juice_agent_t *agent);
+int conn_thread_interrupt(juice_agent_t *agent);
+int conn_thread_send(juice_agent_t *agent, const addr_record_t *dst, const char *data, size_t size,
+                     int ds);
+int conn_thread_get_addrs(juice_agent_t *agent, addr_record_t *records, size_t size);
+
+#endif

--- a/src/server.c
+++ b/src/server.c
@@ -95,7 +95,7 @@ static void delete_allocation(server_turn_alloc_t *alloc) {
 	alloc->credentials = NULL;
 }
 
-thread_return_t THREAD_CALL server_thread_entry(void *arg) {
+static thread_return_t THREAD_CALL server_thread_entry(void *arg) {
 	server_run((juice_server_t *)arg);
 	return (thread_return_t)0;
 }
@@ -261,7 +261,7 @@ void server_do_destroy(juice_server_t *server) {
 void server_destroy(juice_server_t *server) {
 	mutex_lock(&server->mutex);
 
-	JLOG_DEBUG("Waiting for server thread");
+	JLOG_VERBOSE("Waiting for server thread");
 	server->thread_stopped = true;
 	mutex_unlock(&server->mutex);
 	server_interrupt(server);
@@ -356,7 +356,7 @@ void server_run(juice_server_t *server) {
 	const nfds_t nfd = 1 + server->allocs_count;
 	struct pollfd *pfd = calloc(nfd, sizeof(struct pollfd));
 	if (!pfd) {
-		JLOG_FATAL("alloc for poll descriptors failed");
+		JLOG_FATAL("Memory allocation for poll descriptors failed");
 		return;
 	}
 

--- a/src/turn.h
+++ b/src/turn.h
@@ -63,7 +63,7 @@ int turn_wrap_channel_data(char *buffer, size_t size, const char *data, size_t d
 // TURN state map
 
 typedef enum turn_entry_type {
-	TURN_ENTRY_TYPE_EMPTY,
+	TURN_ENTRY_TYPE_EMPTY = 0,
 	TURN_ENTRY_TYPE_DELETED,
 	TURN_ENTRY_TYPE_PERMISSION,
 	TURN_ENTRY_TYPE_CHANNEL

--- a/src/udp.c
+++ b/src/udp.c
@@ -115,8 +115,8 @@ socket_t udp_create_socket(const udp_socket_config_t *config) {
 	setsockopt(sock, SOL_SOCKET, SO_RCVBUF, (const char *)&buffer_size, sizeof(buffer_size));
 	setsockopt(sock, SOL_SOCKET, SO_SNDBUF, (const char *)&buffer_size, sizeof(buffer_size));
 
-	ctl_t blocking = 1;
-	if (ioctlsocket(sock, FIONBIO, &blocking)) {
+	ctl_t nbio = 1;
+	if (ioctlsocket(sock, FIONBIO, &nbio)) {
 		JLOG_ERROR("Setting non-blocking mode on UDP socket failed, errno=%d", sockerrno);
 		goto error;
 	}


### PR DESCRIPTION
This PR introduces an abstraction for ICE agent connections and implements 3 different concurrency mode:
- `POLL`: Each agent has its own UDP socket and agents share a single thread (default)
- `MUX`: Agents share a single UDP socket with multiplexing based on ICE ufrags
- `THREAD`: Each agent has its own UDP socket and thread (original behavior)

The mode can be changed per connection with `concurrency_mode` in config.

Implements https://github.com/paullouisageneau/libjuice/issues/144