### PR TITLE
ability to compile for any 32-bit i386 system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,12 @@ ifneq ($(NO_SERVER), 0)
         CFLAGS+=-DNO_SERVER
 endif
 
+FORCE_M32 ?= 0
+ifneq ($(FORCE_M32), 0)
+        CFLAGS+= -m32
+        LDFLAGS+= -m32
+endif
+
 ifneq ($(LIBS), "")
 INCLUDES+=$(if $(LIBS),$(shell pkg-config --cflags $(LIBS)),)
 LDLIBS+=$(if $(LIBS), $(shell pkg-config --libs $(LIBS)),)


### PR DESCRIPTION
This PR is aimed to add the ability to compile for any i386 32-bit system when building directly with Make.
I see other deps libdatachannel libraries already have this feature via configure.
