### PR TITLE
Change STUN and TURN servers in tests

### DIFF
--- a/test/conflict.c
+++ b/test/conflict.c
@@ -54,17 +54,6 @@ int test_conflict() {
 	juice_config_t config1;
 	memset(&config1, 0, sizeof(config1));
 
-	// TURN server
-	// Please do not use outside of libjuice tests
-	juice_turn_server_t turn_server;
-	memset(&turn_server, 0, sizeof(turn_server));
-	turn_server.host = "stun.ageneau.net";
-	turn_server.port = 3478;
-	turn_server.username = "juice_test";
-	turn_server.password = "28245150316902";
-	config1.turn_servers = &turn_server;
-	config1.turn_servers_count = 1;
-
 	config1.cb_state_changed = on_state_changed1;
 	config1.cb_candidate = on_candidate1;
 	config1.cb_gathering_done = on_gathering_done1;
@@ -76,10 +65,6 @@ int test_conflict() {
 	// Agent 2: Create agent
 	juice_config_t config2;
 	memset(&config2, 0, sizeof(config2));
-
-	// Use the same TURN server
-	config2.turn_servers = &turn_server;
-	config2.turn_servers_count = 1;
 
 	config2.cb_state_changed = on_state_changed2;
 	config2.cb_candidate = on_candidate2;

--- a/test/connectivity.c
+++ b/test/connectivity.c
@@ -54,20 +54,9 @@ int test_connectivity() {
 	juice_config_t config1;
 	memset(&config1, 0, sizeof(config1));
 
-	// STUN server
-	config1.stun_server_host = "stun.stunprotocol.org";
-	config1.stun_server_port = 3478;
-
-	// TURN server
-	// Please do not use outside of libjuice tests
-	juice_turn_server_t turn_server;
-	memset(&turn_server, 0, sizeof(turn_server));
-	turn_server.host = "stun.ageneau.net";
-	turn_server.port = 3478;
-	turn_server.username = "juice_test";
-	turn_server.password = "28245150316902";
-	config1.turn_servers = &turn_server;
-	config1.turn_servers_count = 1;
+	// STUN server example
+	config1.stun_server_host = "stun.l.google.com";
+	config1.stun_server_port = 19302;
 
 	config1.cb_state_changed = on_state_changed1;
 	config1.cb_candidate = on_candidate1;
@@ -81,13 +70,9 @@ int test_connectivity() {
 	juice_config_t config2;
 	memset(&config2, 0, sizeof(config2));
 
-	// STUN server
-	config2.stun_server_host = "stun.stunprotocol.org";
-	config2.stun_server_port = 3478;
-
-	// Use the same TURN server
-	config2.turn_servers = &turn_server;
-	config2.turn_servers_count = 1;
+	// STUN server example
+	config2.stun_server_host = "stun.l.google.com";
+	config2.stun_server_port = 19302;
 
 	// Port range example
 	config2.local_port_range_begin = 60000;

--- a/test/gathering.c
+++ b/test/gathering.c
@@ -48,18 +48,17 @@ int test_gathering() {
 	juice_config_t config;
 	memset(&config, 0, sizeof(config));
 
-	// STUN server
+	// STUN server example (use your own server in production)
 	config.stun_server_host = "stun.stunprotocol.org";
 	config.stun_server_port = 3478;
 
-	// TURN server
-	// Please do not use outside of libjuice tests
+	// TURN server example (use your own server in production)
 	juice_turn_server_t turn_server;
 	memset(&turn_server, 0, sizeof(turn_server));
-	turn_server.host = "stun.ageneau.net";
-	turn_server.port = 3478;
-	turn_server.username = "juice_test";
-	turn_server.password = "28245150316902";
+	turn_server.host = "openrelay.metered.ca";
+	turn_server.port = 80;
+	turn_server.username = "openrelayproject";
+	turn_server.password = "openrelayproject";
 	config.turn_servers = &turn_server;
 	config.turn_servers_count = 1;
 

--- a/test/mux.c
+++ b/test/mux.c
@@ -59,28 +59,13 @@ int test_mux() {
 	// Agent 1: Create agent
 	juice_config_t config1;
 	memset(&config1, 0, sizeof(config1));
-
-	// STUN server
-	config1.stun_server_host = "stun.stunprotocol.org";
-	config1.stun_server_port = 3478;
-
-	// TURN server
-	// Please do not use outside of libjuice tests
-	juice_turn_server_t turn_server;
-	memset(&turn_server, 0, sizeof(turn_server));
-	turn_server.host = "stun.ageneau.net";
-	turn_server.port = 3478;
-	turn_server.username = "juice_test";
-	turn_server.password = "28245150316902";
-	config1.turn_servers = &turn_server;
-	config1.turn_servers_count = 1;
-
+	config1.stun_server_host = "stun.l.google.com";
+	config1.stun_server_port = 19302;
 	config1.cb_state_changed = on_state_changed1;
 	config1.cb_candidate = on_candidate1;
 	config1.cb_gathering_done = on_gathering_done1;
 	config1.cb_recv = on_recv1;
 	config1.user_ptr = NULL;
-
 	agent1 = juice_create(&config1);
 
 	// Agent 2: Create agent in mux mode on port 60000
@@ -89,6 +74,11 @@ int test_mux() {
 	config2.concurrency_mode = JUICE_CONCURRENCY_MODE_MUX;
 	config2.local_port_range_begin = 60000;
 	config2.local_port_range_end = 60000;
+	config2.cb_state_changed = on_state_changed1;
+	config2.cb_candidate = on_candidate1;
+	config2.cb_gathering_done = on_gathering_done1;
+	config2.cb_recv = on_recv1;
+	config2.user_ptr = NULL;
 
 	agent2 = juice_create(&config2);
 

--- a/test/notrickle.c
+++ b/test/notrickle.c
@@ -50,18 +50,8 @@ int test_notrickle() {
 	// Agent 1: Create agent
 	juice_config_t config1;
 	memset(&config1, 0, sizeof(config1));
-
-	// TURN server
-	// Please do not use outside of libjuice tests
-	juice_turn_server_t turn_server;
-	memset(&turn_server, 0, sizeof(turn_server));
-	turn_server.host = "stun.ageneau.net";
-	turn_server.port = 3478;
-	turn_server.username = "juice_test";
-	turn_server.password = "28245150316902";
-	config1.turn_servers = &turn_server;
-	config1.turn_servers_count = 1;
-
+	config1.stun_server_host = "stun.l.google.com";
+	config1.stun_server_port = 19302;
 	config1.cb_state_changed = on_state_changed1;
 	config1.cb_gathering_done = on_gathering_done1;
 	config1.cb_recv = on_recv1;
@@ -78,14 +68,6 @@ int test_notrickle() {
 	config2.cb_gathering_done = on_gathering_done2;
 	config2.cb_recv = on_recv2;
 	config2.user_ptr = NULL;
-
-	// Use the same TURN server
-	config2.turn_servers = &turn_server;
-	config2.turn_servers_count = 1;
-
-	// Port range example
-	config2.local_port_range_begin = 60000;
-	config2.local_port_range_end = 61000;
 
 	agent2 = juice_create(&config2);
 

--- a/test/thread.c
+++ b/test/thread.c
@@ -54,22 +54,8 @@ int test_thread() {
 	juice_config_t config1;
 	memset(&config1, 0, sizeof(config1));
 	config1.concurrency_mode = JUICE_CONCURRENCY_MODE_THREAD;
-
-	// STUN server
-	config1.stun_server_host = "stun.stunprotocol.org";
-	config1.stun_server_port = 3478;
-
-	// TURN server
-	// Please do not use outside of libjuice tests
-	juice_turn_server_t turn_server;
-	memset(&turn_server, 0, sizeof(turn_server));
-	turn_server.host = "stun.ageneau.net";
-	turn_server.port = 3478;
-	turn_server.username = "juice_test";
-	turn_server.password = "28245150316902";
-	config1.turn_servers = &turn_server;
-	config1.turn_servers_count = 1;
-
+	config1.stun_server_host = "stun.l.google.com";
+	config1.stun_server_port = 19302;
 	config1.cb_state_changed = on_state_changed1;
 	config1.cb_candidate = on_candidate1;
 	config1.cb_gathering_done = on_gathering_done1;
@@ -82,15 +68,8 @@ int test_thread() {
 	juice_config_t config2;
 	memset(&config2, 0, sizeof(config2));
 	config2.concurrency_mode = JUICE_CONCURRENCY_MODE_THREAD;
-
-	// STUN server
-	config2.stun_server_host = "stun.stunprotocol.org";
-	config2.stun_server_port = 3478;
-
-	// Use the same TURN server
-	config2.turn_servers = &turn_server;
-	config2.turn_servers_count = 1;
-
+	config2.stun_server_host = "stun.l.google.com";
+	config2.stun_server_port = 19302;
 	config2.cb_state_changed = on_state_changed2;
 	config2.cb_candidate = on_candidate2;
 	config2.cb_gathering_done = on_gathering_done2;


### PR DESCRIPTION
This PR changes STUN and TURN servers in tests as people used my small test server in large-scale production. It also remove TURN servers where they were not necessary.