### PR TITLE
Fix automatic creation of peer reflexive candidate

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -2089,9 +2089,7 @@ int agent_add_remote_reflexive_candidate(juice_agent_t *agent, ice_candidate_typ
 		JLOG_ERROR("Invalid type for remote reflexive candidate");
 		return -1;
 	}
-	int family = record->addr.ss_family;
-	if (ice_find_candidate_from_addr(&agent->remote, record,
-	                                 family == AF_INET6 ? ICE_CANDIDATE_TYPE_UNKNOWN : type)) {
+	if (ice_find_candidate_from_addr(&agent->remote, record, ICE_CANDIDATE_TYPE_UNKNOWN)) {
 		JLOG_VERBOSE("A remote candidate exists for the remote address");
 		return 0;
 	}


### PR DESCRIPTION
This PR fixes the automatic creation of peer reflexive candidates which possibly led to selecting of a pair featuring a peer reflexive candidates while another type would be expected. The candidate priorities should not be impacted.