### PR TITLE
Fix warnings from clang-tidy

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -152,6 +152,7 @@ int conn_create(juice_agent_t *agent, udp_socket_config_t *config) {
 		if (i == registry->agents_size) {
 			int new_size = registry->agents_size * 2;
 			JLOG_DEBUG("Reallocating connections array, new_size=%d", new_size);
+			assert(new_size > 0);
 
 			juice_agent_t **new_agents =
 			    realloc(registry->agents, new_size * sizeof(juice_agent_t *));

--- a/src/conn_poll.c
+++ b/src/conn_poll.c
@@ -152,6 +152,7 @@ int conn_poll_prepare(conn_registry_t *registry, pfds_record_t *pfds, timestamp_
 
 	registry_impl_t *registry_impl = registry->impl;
 	struct pollfd *interrupt_pfd = pfds->pfds;
+	assert(interrupt_pfd);
 #ifdef _WIN32
 	interrupt_pfd->fd = registry_impl->interrupt_sock;
 #else

--- a/src/stun.c
+++ b/src/stun.c
@@ -421,11 +421,14 @@ int stun_write_attr(void *buf, size_t size, uint16_t type, const void *value, si
 	struct stun_attr *attr = buf;
 	attr->type = htons(type);
 	attr->length = htons((uint16_t)length);
-	memcpy(attr->value, value, length);
 
-	// Pad to align on 4 bytes
-	while (length & 0x03)
-		attr->value[length++] = 0;
+	if (length > 0) {
+		memcpy(attr->value, value, length);
+
+		// Pad to align on 4 bytes
+		while (length & 0x03)
+			attr->value[length++] = 0;
+	}
 
 	return (int)(sizeof(struct stun_attr) + length);
 }


### PR DESCRIPTION
This PR fixes warnings after adding clang-tidy in https://github.com/paullouisageneau/libjuice/pull/177