### PR TITLE
Fix export define for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ target_include_directories(juice-static PUBLIC
 target_include_directories(juice-static PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/juice)
 target_include_directories(juice-static PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_compile_definitions(juice-static PRIVATE $<$<CONFIG:Release>:RELEASE=1>)
+target_compile_definitions(juice-static PUBLIC JUICE_STATIC)
 target_link_libraries(juice-static PRIVATE Threads::Threads)
 
 if(WIN32)
@@ -175,11 +176,18 @@ install(FILES ${CMAKE_BINARY_DIR}/LibJuiceConfigVersion.cmake
 
 if(NOT NO_EXPORT_HEADER AND CMAKE_VERSION VERSION_GREATER_EQUAL "3.12")
 	include(GenerateExportHeader)
-	generate_export_header(juice)
+	generate_export_header(juice
+		EXPORT_MACRO_NAME JUICE_EXPORT
+		NO_EXPORT_MACRO_NAME JUICE_NO_EXPORT
+		DEPRECATED_MACRO_NAME JUICE_DEPRECATED
+		STATIC_DEFINE JUICE_STATIC)
 	target_include_directories(juice PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 	target_compile_definitions(juice PUBLIC -DJUICE_HAS_EXPORT_HEADER)
 	set_target_properties(juice PROPERTIES C_VISIBILITY_PRESET hidden)
 	install(FILES ${PROJECT_BINARY_DIR}/juice_export.h DESTINATION include/juice)
+else()
+	target_compile_definitions(juice PRIVATE JUICE_EXPORTS)
+	target_compile_definitions(juice-static PRIVATE JUICE_EXPORTS)
 endif()
 
 if(NOT MSVC)

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ ifneq ($(FORCE_M32), 0)
         LDFLAGS+= -m32
 endif
 
+CFLAGS+=-DJUICE_EXPORTS
+
 ifneq ($(LIBS), "")
 INCLUDES+=$(if $(LIBS),$(shell pkg-config --cflags $(LIBS)),)
 LDLIBS+=$(if $(LIBS), $(shell pkg-config --libs $(LIBS)),)

--- a/include/juice/juice.h
+++ b/include/juice/juice.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Paul-Louis Ageneau
+ * Copyright (c) 2020-2022 Paul-Louis Ageneau
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -29,13 +29,19 @@ extern "C" {
 
 #ifdef JUICE_HAS_EXPORT_HEADER
 #include "juice_export.h"
-#endif
-
-#ifndef JUICE_EXPORT
-#ifdef _WIN32
-#define JUICE_EXPORT __declspec(dllexport)
-#else
+#else // no export header
+#ifdef JUICE_STATIC
 #define JUICE_EXPORT
+#else // dynamic library
+#ifdef _WIN32
+#if defined(JUICE_EXPORTS) || defined(juice_EXPORTS)
+#define JUICE_EXPORT __declspec(dllexport) // building the library
+#else
+#define JUICE_EXPORT __declspec(dllimport) // using the library
+#endif
+#else // not WIN32
+#define JUICE_EXPORT
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
This PR fixes the export define for Windows when not using the export header, as previously it would lead to incorrect behavior, for instance re-exported symbols when used as a static library in a dynamic library.