### PR TITLE
Implement ICE Patiently Awaiting Connectivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The library implements a simplified but fully compatible ICE agent ([RFC5245](ht
 - STUN protocol ([RFC5389](https://www.rfc-editor.org/rfc/rfc5389.html) then [RFC8489](https://www.rfc-editor.org/rfc/rfc8489.html))
 - TURN relaying ([RFC5766](https://www.rfc-editor.org/rfc/rfc5766.html) then [RFC8656](https://www.rfc-editor.org/rfc/rfc8656.html))
 - Consent freshness ([RFC7675](https://www.rfc-editor.org/rfc/rfc7675.html))
+- Patiently Awaiting Connectivity ([RFC 8863](https://www.rfc-editor.org/rfc/rfc8863.html))
 - SDP-based interface ([RFC8839](https://www.rfc-editor.org/rfc/rfc8839.html))
 - IPv4 and IPv6 dual-stack support
 - Optional multiplexing on a single UDP port


### PR DESCRIPTION
This PR implements ICE PAC (Patiently Awaiting Connectivity) as specified in [RFC 8863](https://www.rfc-editor.org/rfc/rfc8863.html) and changes the STUN retransmission timings to align with the defaults from [RFC 8489](https://www.rfc-editor.org/rfc/rfc8489.html#section-6.2.1).