### PR TITLE
Fix end-of-candidates attribute parsing in description

### DIFF
--- a/src/ice.c
+++ b/src/ice.c
@@ -42,7 +42,7 @@ static int parse_sdp_line(const char *line, ice_description_t *description) {
 		sscanf(arg, "%256s", description->ice_pwd);
 		return 0;
 	}
-	if (match_prefix(line, "a=end-of-candidates:", &arg)) {
+	if (match_prefix(line, "a=end-of-candidates", &arg)) {
 		description->finished = true;
 		return 0;
 	}


### PR DESCRIPTION
This PR fixes the parsing of end-of-candidates attribute which was ignored due to a typo.