### PR TITLE
Fix SDP parsing error logging

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -456,19 +456,13 @@ int agent_set_remote_description(juice_agent_t *agent, const char *sdp) {
 	ice_description_t remote;
 	int ret = ice_parse_sdp(sdp, &remote);
 	if (ret < 0) {
-		if (ret == ICE_PARSE_ERROR)
+		if (ret == ICE_PARSE_MISSING_UFRAG)
+			JLOG_ERROR("Missing ICE user fragment in remote description");
+		else if (ret == ICE_PARSE_MISSING_PWD)
+			JLOG_ERROR("Missing ICE password in remote description");
+		else
 			JLOG_ERROR("Failed to parse remote SDP description");
 
-		conn_unlock(agent);
-		return -1;
-	}
-	if (!*remote.ice_ufrag) {
-		JLOG_ERROR("Missing ICE user fragment in remote description");
-		conn_unlock(agent);
-		return -1;
-	}
-	if (!*remote.ice_pwd) {
-		JLOG_ERROR("Missing ICE password in remote description");
 		conn_unlock(agent);
 		return -1;
 	}

--- a/src/ice.c
+++ b/src/ice.c
@@ -105,7 +105,9 @@ int ice_parse_sdp(const char *sdp, ice_description_t *description) {
 		if (*sdp == '\n') {
 			if (size) {
 				buffer[size++] = '\0';
-				parse_sdp_line(buffer, description);
+				if(parse_sdp_line(buffer, description) == ICE_PARSE_ERROR)
+					return ICE_PARSE_ERROR;
+
 				size = 0;
 			}
 		} else if (*sdp != '\r' && size + 1 < BUFFER_SIZE) {
@@ -118,7 +120,13 @@ int ice_parse_sdp(const char *sdp, ice_description_t *description) {
 	JLOG_DEBUG("Parsed remote description: ufrag=\"%s\", pwd=\"%s\", candidates=%d",
 	           description->ice_ufrag, description->ice_pwd, description->candidates_count);
 
-	return *description->ice_ufrag && *description->ice_pwd ? 0 : ICE_PARSE_ERROR;
+	if (*description->ice_ufrag == '\0')
+		return ICE_PARSE_MISSING_UFRAG;
+
+	if (*description->ice_pwd == '\0')
+		return ICE_PARSE_MISSING_PWD;
+
+	return 0;
 }
 
 int ice_parse_candidate_sdp(const char *line, ice_candidate_t *candidate) {

--- a/src/ice.h
+++ b/src/ice.h
@@ -76,6 +76,8 @@ typedef enum ice_resolve_mode {
 
 #define ICE_PARSE_ERROR -1
 #define ICE_PARSE_IGNORED -2
+#define ICE_PARSE_MISSING_UFRAG -3
+#define ICE_PARSE_MISSING_PWD -4
 
 int ice_parse_sdp(const char *sdp, ice_description_t *description);
 int ice_parse_candidate_sdp(const char *line, ice_candidate_t *candidate);


### PR DESCRIPTION
This PR fixes SDP parsing error logging so the library actually logs specific messages when ICE user fragment or password are missing instead of a generic message.