### PR TITLE
Add support for ice-lite in remote description

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For a STUN/TURN server application based on libjuice, see [Violet](https://githu
 
 ## Compatibility
 
-The library implements a simplified but fully compatible ICE agent ([RFC5245](https://www.rfc-editor.org/rfc/rfc5245.html) then [RFC8445](https://www.rfc-editor.org/rfc/rfc8445.html)) featuring:
+The library implements a simplified full ICE agent ([RFC5245](https://www.rfc-editor.org/rfc/rfc5245.html) then [RFC8445](https://www.rfc-editor.org/rfc/rfc8445.html)) featuring:
 - STUN protocol ([RFC5389](https://www.rfc-editor.org/rfc/rfc5389.html) then [RFC8489](https://www.rfc-editor.org/rfc/rfc8489.html))
 - TURN relaying ([RFC5766](https://www.rfc-editor.org/rfc/rfc5766.html) then [RFC8656](https://www.rfc-editor.org/rfc/rfc8656.html))
 - ICE Consent freshness ([RFC7675](https://www.rfc-editor.org/rfc/rfc7675.html))

--- a/src/agent.c
+++ b/src/agent.c
@@ -487,7 +487,13 @@ int agent_set_remote_description(juice_agent_t *agent, const char *sdp) {
 
 	agent_update_pac_timer(agent);
 
-	if (agent->mode == AGENT_MODE_UNKNOWN) {
+	if (agent->remote.ice_lite && agent->mode != AGENT_MODE_CONTROLLING) {
+		// RFC 8445 6.1.1. Determining Role:
+		// The full agent MUST take the controlling role, and the lite agent MUST take the
+		// controlled role.
+		JLOG_DEBUG("Remote ICE agent is lite, assuming controlling mode");
+		agent->mode = AGENT_MODE_CONTROLLING;
+	} else if (agent->mode == AGENT_MODE_UNKNOWN) {
 		JLOG_DEBUG("Assuming controlled mode");
 		agent->mode = AGENT_MODE_CONTROLLED;
 	}

--- a/src/ice.h
+++ b/src/ice.h
@@ -47,6 +47,7 @@ typedef struct ice_candidate {
 typedef struct ice_description {
 	char ice_ufrag[256 + 1]; // 4 to 256 characters
 	char ice_pwd[256 + 1];   // 22 to 256 characters
+	bool ice_lite;
 	ice_candidate_t candidates[ICE_MAX_CANDIDATES_COUNT];
 	int candidates_count;
 	bool finished;


### PR DESCRIPTION
This PR adds support for the `ice-lite` attribute in remote description, as specified by [RFC 8839](https://www.rfc-editor.org/rfc/rfc8839.html).