### PR TITLE
Use SENETUNREACH to fix some windows builds

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -1598,7 +1598,7 @@ int agent_send_stun_binding(juice_agent_t *agent, agent_stun_entry_t *entry, stu
 	// Direct send
 	int ret = agent_direct_send(agent, &entry->record, buffer, size, 0);
 	if (ret < 0) {
-		if (ret == ENETUNREACH)
+		if (ret == SENETUNREACH)
 			JLOG_INFO("STUN binding failed: Network unreachable");
 		else
 			JLOG_WARN("STUN message send failed");


### PR DESCRIPTION
In src/socket.h SENETUNREACH is already defined as WSAENETUNREACH on Windows and ENETUNREACH on Linux.

While I'm unable to reproduce the build error locally (likely due to different mingw versions), I'm seeing github actions failing for the Godot WebRTC plugin [here](https://github.com/Faless/webrtc-native/actions/runs/6597706986/job/17924964327).

```
/home/runner/work/webrtc-native/webrtc-native/thirdparty/libdatachannel/deps/libjuice/src/agent.c:1601:14: error: 'ENETUNREACH' undeclared (first use in this function); did you mean 'SENETUNREACH'?
 1601 |   if (ret == ENETUNREACH)
      |              ^~~~~~~~~~~
      |              SENETUNREACH
```

Looking at `src/socket.h` I can see that it was properly set up to handle the different WSA/Posix socket cases correctly already:

https://github.com/paullouisageneau/libjuice/blob/a1f4037aec9353ac3928ce4dcda1229b68db64b2/src/socket.h#L59

and 

https://github.com/paullouisageneau/libjuice/blob/a1f4037aec9353ac3928ce4dcda1229b68db64b2/src/socket.h#L108