### PR TITLE
Remove deprecated ATOMIC_VAR_INIT macro

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -128,7 +128,7 @@ juice_agent_t *agent_create(const juice_config_t *config) {
 
 	agent->state = JUICE_STATE_DISCONNECTED;
 	agent->mode = AGENT_MODE_UNKNOWN;
-	agent->selected_entry = ATOMIC_VAR_INIT(NULL);
+	agent->selected_entry = NULL;
 
 	agent->conn_index = -1;
 	agent->conn_impl = NULL;

--- a/src/log.c
+++ b/src/log.c
@@ -33,7 +33,7 @@ static const char *log_level_colors[] = {
 
 static mutex_t log_mutex = MUTEX_INITIALIZER;
 static volatile juice_log_cb_t log_cb = NULL;
-static atomic(juice_log_level_t) log_level = ATOMIC_VAR_INIT(JUICE_LOG_LEVEL_WARN);
+static atomic(juice_log_level_t) log_level = JUICE_LOG_LEVEL_WARN;
 
 static bool use_color(void) {
 #ifdef _WIN32

--- a/src/thread.h
+++ b/src/thread.h
@@ -141,7 +141,6 @@ static inline void thread_set_name_self(const char *name) {
 #define atomic_ptr(T) T *volatile
 #define atomic_store(a, v) (void)(*(a) = (v))
 #define atomic_load(a) (*(a))
-#define ATOMIC_VAR_INIT(v) (v)
 
 #endif // if atomics
 


### PR DESCRIPTION
This PR removes the `ATOMIC_VAR_INIT` macro. It is useless in C11, deprecated in C17, and removed in C23.