### PR TITLE
Add support for setting ICE ufrag and pwd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ set(TESTS_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/test/server.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test/conflict.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test/bind.c
+	${CMAKE_CURRENT_SOURCE_DIR}/test/ufrag.c
 )
 source_group("Test Files" FILES "${TESTS_SOURCES}")
 

--- a/include/juice/juice.h
+++ b/include/juice/juice.h
@@ -91,9 +91,6 @@ typedef struct juice_config {
 	uint16_t local_port_range_begin;
 	uint16_t local_port_range_end;
 
-	const char *ice_ufrag;
-	const char *ice_pwd;
-
 	juice_cb_state_changed_t cb_state_changed;
 	juice_cb_candidate_t cb_candidate;
 	juice_cb_gathering_done_t cb_gathering_done;
@@ -119,6 +116,7 @@ JUICE_EXPORT int juice_get_selected_candidates(juice_agent_t *agent, char *local
                                                char *remote, size_t remote_size);
 JUICE_EXPORT int juice_get_selected_addresses(juice_agent_t *agent, char *local, size_t local_size,
                                               char *remote, size_t remote_size);
+JUICE_EXPORT int juice_set_local_ice_attributes(juice_agent_t *agent, const char *ufrag, const char *pwd);
 JUICE_EXPORT const char *juice_state_to_string(juice_state_t state);
 
 // ICE server

--- a/include/juice/juice.h
+++ b/include/juice/juice.h
@@ -91,6 +91,9 @@ typedef struct juice_config {
 	uint16_t local_port_range_begin;
 	uint16_t local_port_range_end;
 
+	const char *ice_ufrag;
+	const char *ice_pwd;
+
 	juice_cb_state_changed_t cb_state_changed;
 	juice_cb_candidate_t cb_candidate;
 	juice_cb_gathering_done_t cb_gathering_done;

--- a/src/agent.c
+++ b/src/agent.c
@@ -135,14 +135,6 @@ juice_agent_t *agent_create(const juice_config_t *config) {
 
 	ice_create_local_description(&agent->local);
 
-	if (config->ice_ufrag) {
-		strncpy(agent->local.ice_ufrag, config->ice_ufrag, sizeof(agent->local.ice_ufrag));
-	}
-
-	if (config->ice_pwd) {
-		strncpy(agent->local.ice_pwd, config->ice_pwd, sizeof(agent->local.ice_pwd));
-	}
-
 	// RFC 8445: 16.1. Attributes
 	// The content of the [ICE-CONTROLLED/ICE-CONTROLLING] attribute is a 64-bit
 	// unsigned integer in network byte order, which contains a random number.

--- a/src/agent.c
+++ b/src/agent.c
@@ -135,6 +135,14 @@ juice_agent_t *agent_create(const juice_config_t *config) {
 
 	ice_create_local_description(&agent->local);
 
+	if (config->ice_ufrag) {
+		strncpy(agent->local.ice_ufrag, config->ice_ufrag, sizeof(agent->local.ice_ufrag));
+	}
+
+	if (config->ice_pwd) {
+		strncpy(agent->local.ice_pwd, config->ice_pwd, sizeof(agent->local.ice_pwd));
+	}
+
 	// RFC 8445: 16.1. Attributes
 	// The content of the [ICE-CONTROLLED/ICE-CONTROLLING] attribute is a 64-bit
 	// unsigned integer in network byte order, which contains a random number.

--- a/src/juice.c
+++ b/src/juice.c
@@ -16,6 +16,7 @@
 #endif
 
 #include <stdio.h>
+#include <string.h>
 
 JUICE_EXPORT juice_agent_t *juice_create(const juice_config_t *config) {
 	if (!config)
@@ -143,6 +144,14 @@ JUICE_EXPORT int juice_get_selected_addresses(juice_agent_t *agent, char *local,
 
 	if (remote_size && addr_record_to_string(&remote_cand.resolved, remote, remote_size) < 0)
 		return JUICE_ERR_FAILED;
+
+	return JUICE_ERR_SUCCESS;
+}
+
+int juice_set_local_ice_attributes(juice_agent_t *agent, const char *ufrag, const char *pwd)
+{
+	strncpy(agent->local.ice_ufrag, ufrag, sizeof(agent->local.ice_ufrag));
+	strncpy(agent->local.ice_pwd, pwd, sizeof(agent->local.ice_pwd));
 
 	return JUICE_ERR_SUCCESS;
 }

--- a/src/juice.c
+++ b/src/juice.c
@@ -150,8 +150,18 @@ JUICE_EXPORT int juice_get_selected_addresses(juice_agent_t *agent, char *local,
 
 int juice_set_local_ice_attributes(juice_agent_t *agent, const char *ufrag, const char *pwd)
 {
-	strncpy(agent->local.ice_ufrag, ufrag, sizeof(agent->local.ice_ufrag));
-	strncpy(agent->local.ice_pwd, pwd, sizeof(agent->local.ice_pwd));
+	if (agent->conn_impl) {
+		JLOG_WARN("Candidates gathering already started");
+		return JUICE_ERR_FAILED;
+	}
+
+	if (!ufrag || !pwd || strlen(ufrag) < 4 || strlen(pwd) < 22) {
+		JLOG_WARN("Invalid ICE credentials");
+		return JUICE_ERR_INVALID;
+	}
+
+	snprintf(agent->local.ice_ufrag, sizeof(agent->local.ice_ufrag), "%s", ufrag);
+	snprintf(agent->local.ice_pwd, sizeof(agent->local.ice_pwd), "%s", pwd);
 
 	return JUICE_ERR_SUCCESS;
 }

--- a/test/main.c
+++ b/test/main.c
@@ -21,6 +21,7 @@ int test_gathering(void);
 int test_turn(void);
 int test_conflict(void);
 int test_bind(void);
+int test_ufrag(void);
 
 #ifndef NO_SERVER
 int test_server(void);
@@ -94,6 +95,12 @@ int main(int argc, char **argv) {
 	printf("\nRunning connectivity test with bind address...\n");
 	if (test_bind()) {
 		fprintf(stderr, "Connectivity test with bind address failed\n");
+		return -1;
+	}
+
+	printf("\nRunning ufrag test...\n");
+	if (test_ufrag()) {
+		fprintf(stderr, "Ufrag test failed\n");
 		return -1;
 	}
 

--- a/test/ufrag.c
+++ b/test/ufrag.c
@@ -23,11 +23,10 @@ int test_ufrag() {
 	juice_config_t config;
 	memset(&config, 0, sizeof(config));
 
-	// STUN server example
-	config.ice_ufrag = "ufrag";
-	config.ice_pwd = "pwd";
-
 	agent = juice_create(&config);
+
+	// Set local ICE attributes
+	juice_set_local_ice_attributes(agent, "ufrag", "pwd");
 
 	// Generate local description
 	char sdp[JUICE_MAX_SDP_STRING_LEN];

--- a/test/ufrag.c
+++ b/test/ufrag.c
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2024 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "juice/juice.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+int test_ufrag() {
+	juice_agent_t *agent;
+	bool success = true;
+
+	juice_set_log_level(JUICE_LOG_LEVEL_DEBUG);
+
+	// Create agent
+	juice_config_t config;
+	memset(&config, 0, sizeof(config));
+
+	// STUN server example
+	config.ice_ufrag = "ufrag";
+	config.ice_pwd = "pwd";
+
+	agent = juice_create(&config);
+
+	// Generate local description
+	char sdp[JUICE_MAX_SDP_STRING_LEN];
+	juice_get_local_description(agent, sdp, JUICE_MAX_SDP_STRING_LEN);
+	printf("Local description:\n%s\n", sdp);
+
+	if (strstr(sdp, "a=ice-ufrag:ufrag\r\n") == NULL)
+		success = false;
+
+	if (strstr(sdp, "a=ice-pwd:pwd\r\n") == NULL)
+		success = false;
+
+	// Destroy
+	juice_destroy(agent);
+
+	if (success) {
+		printf("Success\n");
+		return 0;
+	} else {
+		printf("Failure\n");
+		return -1;
+	}
+}

--- a/test/ufrag.c
+++ b/test/ufrag.c
@@ -16,6 +16,7 @@
 int test_ufrag() {
 	juice_agent_t *agent;
 	bool success = true;
+	int ret;
 
 	juice_set_log_level(JUICE_LOG_LEVEL_DEBUG);
 
@@ -25,8 +26,24 @@ int test_ufrag() {
 
 	agent = juice_create(&config);
 
+	if (juice_set_local_ice_attributes(agent, NULL, NULL) != JUICE_ERR_INVALID)
+		success = false;
+
+	if (juice_set_local_ice_attributes(agent, "ufrag", NULL) != JUICE_ERR_INVALID)
+		success = false;
+
+	if (juice_set_local_ice_attributes(agent, NULL, "pw01234567890123456789") != JUICE_ERR_INVALID)
+		success = false;
+
+	if (juice_set_local_ice_attributes(agent, "ufrag", "pw0123456789012345678") != JUICE_ERR_INVALID)
+		success = false;
+
+	if (juice_set_local_ice_attributes(agent, "usr", "pw01234567890123456789") != JUICE_ERR_INVALID)
+		success = false;
+
+
 	// Set local ICE attributes
-	juice_set_local_ice_attributes(agent, "ufrag", "pwd");
+	juice_set_local_ice_attributes(agent, "ufrag", "pw01234567890123456789");
 
 	// Generate local description
 	char sdp[JUICE_MAX_SDP_STRING_LEN];
@@ -36,7 +53,7 @@ int test_ufrag() {
 	if (strstr(sdp, "a=ice-ufrag:ufrag\r\n") == NULL)
 		success = false;
 
-	if (strstr(sdp, "a=ice-pwd:pwd\r\n") == NULL)
+	if (strstr(sdp, "a=ice-pwd:pw01234567890123456789\r\n") == NULL)
 		success = false;
 
 	// Destroy


### PR DESCRIPTION
In order to support Peer A and Peer B in WebRTC Direct, we need to be able to specify the ufrag and pwd of the localDescription. WebRTC Direct's documentation suggests replacing the ufrag and pwd with setLocalDescription. This is not compliant with the standard.

Therefore, I propose another solution, we can set ufrag and pwd in juice_create, which can satisfy both Peer A and Peer B's needs, and will not modify the existing logic in any way.