### PR TITLE
Add callback to get unhandled STUN binding requests from mux

### DIFF
--- a/include/juice/juice.h
+++ b/include/juice/juice.h
@@ -63,7 +63,17 @@ typedef void (*juice_cb_candidate_t)(juice_agent_t *agent, const char *sdp, void
 typedef void (*juice_cb_gathering_done_t)(juice_agent_t *agent, void *user_ptr);
 typedef void (*juice_cb_recv_t)(juice_agent_t *agent, const char *data, size_t size,
                                 void *user_ptr);
-typedef void (*juice_cb_stun_binding_t)(const char *ufrag, const char *pwd, const char *bind_address);
+
+typedef struct juice_stun_binding {
+	const char *ufrag;
+	const char *pwd;
+
+	uint8_t family;
+	const char *address;
+	uint16_t port;
+} juice_stun_binding_t;
+
+typedef void (*juice_cb_stun_binding_t)(const juice_stun_binding_t *info);
 
 typedef struct juice_turn_server {
 	const char *host;

--- a/include/juice/juice.h
+++ b/include/juice/juice.h
@@ -64,16 +64,15 @@ typedef void (*juice_cb_gathering_done_t)(juice_agent_t *agent, void *user_ptr);
 typedef void (*juice_cb_recv_t)(juice_agent_t *agent, const char *data, size_t size,
                                 void *user_ptr);
 
-typedef struct juice_stun_binding {
+typedef struct juice_mux_incoming {
 	const char *ufrag;
 	const char *pwd;
 
-	uint8_t family;
 	const char *address;
 	uint16_t port;
-} juice_stun_binding_t;
+} juice_mux_incoming_t;
 
-typedef void (*juice_cb_stun_binding_t)(const juice_stun_binding_t *info, void *user_ptr);
+typedef void (*juice_cb_mux_incoming_t)(const juice_mux_incoming_t *info, void *user_ptr);
 
 typedef struct juice_turn_server {
 	const char *host;
@@ -129,8 +128,8 @@ JUICE_EXPORT int juice_get_selected_addresses(juice_agent_t *agent, char *local,
                                               char *remote, size_t remote_size);
 JUICE_EXPORT int juice_set_local_ice_attributes(juice_agent_t *agent, const char *ufrag, const char *pwd);
 JUICE_EXPORT const char *juice_state_to_string(juice_state_t state);
-JUICE_EXPORT int juice_bind_stun(const char *bind_address, int local_port, juice_cb_stun_binding_t cb, void *user_ptr);
-JUICE_EXPORT int juice_unbind_stun();
+JUICE_EXPORT int juice_mux_listen(const char *bind_address, int local_port, juice_cb_mux_incoming_t cb, void *user_ptr);
+JUICE_EXPORT int juice_mux_stop_listen(const char *bind_address, int local_port);
 
 // ICE server
 

--- a/include/juice/juice.h
+++ b/include/juice/juice.h
@@ -64,15 +64,15 @@ typedef void (*juice_cb_gathering_done_t)(juice_agent_t *agent, void *user_ptr);
 typedef void (*juice_cb_recv_t)(juice_agent_t *agent, const char *data, size_t size,
                                 void *user_ptr);
 
-typedef struct juice_mux_incoming {
+typedef struct juice_mux_binding_request {
 	const char *local_ufrag;
 	const char *remote_ufrag;
 
 	const char *address;
 	uint16_t port;
-} juice_mux_incoming_t;
+} juice_mux_binding_request_t;
 
-typedef void (*juice_cb_mux_incoming_t)(const juice_mux_incoming_t *info, void *user_ptr);
+typedef void (*juice_cb_mux_incoming_t)(const juice_mux_binding_request_t *info, void *user_ptr);
 
 typedef struct juice_turn_server {
 	const char *host;
@@ -129,7 +129,6 @@ JUICE_EXPORT int juice_get_selected_addresses(juice_agent_t *agent, char *local,
 JUICE_EXPORT int juice_set_local_ice_attributes(juice_agent_t *agent, const char *ufrag, const char *pwd);
 JUICE_EXPORT const char *juice_state_to_string(juice_state_t state);
 JUICE_EXPORT int juice_mux_listen(const char *bind_address, int local_port, juice_cb_mux_incoming_t cb, void *user_ptr);
-JUICE_EXPORT int juice_mux_stop_listen(const char *bind_address, int local_port);
 
 // ICE server
 

--- a/include/juice/juice.h
+++ b/include/juice/juice.h
@@ -63,6 +63,7 @@ typedef void (*juice_cb_candidate_t)(juice_agent_t *agent, const char *sdp, void
 typedef void (*juice_cb_gathering_done_t)(juice_agent_t *agent, void *user_ptr);
 typedef void (*juice_cb_recv_t)(juice_agent_t *agent, const char *data, size_t size,
                                 void *user_ptr);
+typedef void (*juice_cb_stun_binding_t)(const char *ufrag, const char *pwd, const char *bind_address);
 
 typedef struct juice_turn_server {
 	const char *host;
@@ -118,6 +119,7 @@ JUICE_EXPORT int juice_get_selected_addresses(juice_agent_t *agent, char *local,
                                               char *remote, size_t remote_size);
 JUICE_EXPORT int juice_set_local_ice_attributes(juice_agent_t *agent, const char *ufrag, const char *pwd);
 JUICE_EXPORT const char *juice_state_to_string(juice_state_t state);
+JUICE_EXPORT int juice_bind_stun(const char *bind_address, int local_port, juice_cb_stun_binding_t cb);
 
 // ICE server
 

--- a/include/juice/juice.h
+++ b/include/juice/juice.h
@@ -65,8 +65,8 @@ typedef void (*juice_cb_recv_t)(juice_agent_t *agent, const char *data, size_t s
                                 void *user_ptr);
 
 typedef struct juice_mux_incoming {
-	const char *ufrag;
-	const char *pwd;
+	const char *remote_ufrag;
+	const char *local_ufrag;
 
 	const char *address;
 	uint16_t port;

--- a/include/juice/juice.h
+++ b/include/juice/juice.h
@@ -73,7 +73,7 @@ typedef struct juice_stun_binding {
 	uint16_t port;
 } juice_stun_binding_t;
 
-typedef void (*juice_cb_stun_binding_t)(const juice_stun_binding_t *info);
+typedef void (*juice_cb_stun_binding_t)(const juice_stun_binding_t *info, void *user_ptr);
 
 typedef struct juice_turn_server {
 	const char *host;
@@ -129,7 +129,7 @@ JUICE_EXPORT int juice_get_selected_addresses(juice_agent_t *agent, char *local,
                                               char *remote, size_t remote_size);
 JUICE_EXPORT int juice_set_local_ice_attributes(juice_agent_t *agent, const char *ufrag, const char *pwd);
 JUICE_EXPORT const char *juice_state_to_string(juice_state_t state);
-JUICE_EXPORT int juice_bind_stun(const char *bind_address, int local_port, juice_cb_stun_binding_t cb);
+JUICE_EXPORT int juice_bind_stun(const char *bind_address, int local_port, juice_cb_stun_binding_t cb, void *user_ptr);
 JUICE_EXPORT int juice_unbind_stun();
 
 // ICE server

--- a/include/juice/juice.h
+++ b/include/juice/juice.h
@@ -130,6 +130,7 @@ JUICE_EXPORT int juice_get_selected_addresses(juice_agent_t *agent, char *local,
 JUICE_EXPORT int juice_set_local_ice_attributes(juice_agent_t *agent, const char *ufrag, const char *pwd);
 JUICE_EXPORT const char *juice_state_to_string(juice_state_t state);
 JUICE_EXPORT int juice_bind_stun(const char *bind_address, int local_port, juice_cb_stun_binding_t cb);
+JUICE_EXPORT int juice_unbind_stun();
 
 // ICE server
 

--- a/include/juice/juice.h
+++ b/include/juice/juice.h
@@ -65,8 +65,8 @@ typedef void (*juice_cb_recv_t)(juice_agent_t *agent, const char *data, size_t s
                                 void *user_ptr);
 
 typedef struct juice_mux_incoming {
-	const char *remote_ufrag;
 	const char *local_ufrag;
+	const char *remote_ufrag;
 
 	const char *address;
 	uint16_t port;

--- a/src/conn.c
+++ b/src/conn.c
@@ -266,6 +266,9 @@ int juice_bind_stun(const char *bind_address, int local_port, juice_cb_stun_bind
 	conn_registry_t *registry = acquire_registry(entry, &config);
 	mutex_unlock(&entry->mutex);
 
+	if (!registry)
+		return -2;
+
 	registry->cb_stun_binding = cb;
 	mutex_unlock(&registry->mutex);
 

--- a/src/conn.c
+++ b/src/conn.c
@@ -262,6 +262,7 @@ int juice_unbind_stun() {
 	mutex_lock(&registry->mutex);
 
 	registry->cb_stun_binding = NULL;
+	registry->stun_binding_user_ptr = NULL;
 	conn_mux_interrupt_registry(registry);
 
 	release_registry(entry);
@@ -271,7 +272,7 @@ int juice_unbind_stun() {
 	return 0;
 }
 
-int juice_bind_stun(const char *bind_address, int local_port, juice_cb_stun_binding_t cb)
+int juice_bind_stun(const char *bind_address, int local_port, juice_cb_stun_binding_t cb, void *user_ptr)
 {
 	conn_mode_entry_t *entry = &mode_entries[JUICE_CONCURRENCY_MODE_MUX];
 
@@ -293,6 +294,7 @@ int juice_bind_stun(const char *bind_address, int local_port, juice_cb_stun_bind
 		return -2;
 
 	registry->cb_stun_binding = cb;
+	registry->stun_binding_user_ptr = user_ptr;
 	mutex_unlock(&registry->mutex);
 
 	return 0;

--- a/src/conn.c
+++ b/src/conn.c
@@ -248,7 +248,7 @@ int conn_get_addrs(juice_agent_t *agent, addr_record_t *records, size_t size) {
 	return get_mode_entry(agent)->get_addrs_func(agent, records, size);
 }
 
-int juice_mux_stop_listen(const char *bind_address, int local_port) {
+static int juice_mux_stop_listen(const char *bind_address, int local_port) {
     (void)bind_address;
     (void)local_port;
 
@@ -277,6 +277,9 @@ int juice_mux_stop_listen(const char *bind_address, int local_port) {
 
 int juice_mux_listen(const char *bind_address, int local_port, juice_cb_mux_incoming_t cb, void *user_ptr)
 {
+	if (!cb)
+		return juice_mux_stop_listen(bind_address, local_port);
+
 	conn_mode_entry_t *entry = &mode_entries[JUICE_CONCURRENCY_MODE_MUX];
 
 	udp_socket_config_t config;

--- a/src/conn.h
+++ b/src/conn.h
@@ -30,8 +30,8 @@ typedef struct conn_registry {
 	juice_agent_t **agents;
 	int agents_size;
 	int agents_count;
-	juice_cb_stun_binding_t cb_stun_binding;
-	void *stun_binding_user_ptr;
+	juice_cb_mux_incoming_t cb_mux_incoming;
+	void *mux_incoming_user_ptr;
 } conn_registry_t;
 
 int conn_create(juice_agent_t *agent, udp_socket_config_t *config);

--- a/src/conn.h
+++ b/src/conn.h
@@ -31,6 +31,7 @@ typedef struct conn_registry {
 	int agents_size;
 	int agents_count;
 	juice_cb_stun_binding_t cb_stun_binding;
+	void *stun_binding_user_ptr;
 } conn_registry_t;
 
 int conn_create(juice_agent_t *agent, udp_socket_config_t *config);

--- a/src/conn.h
+++ b/src/conn.h
@@ -30,6 +30,7 @@ typedef struct conn_registry {
 	juice_agent_t **agents;
 	int agents_size;
 	int agents_count;
+	juice_cb_stun_binding_t cb_stun_binding;
 } conn_registry_t;
 
 int conn_create(juice_agent_t *agent, udp_socket_config_t *config);

--- a/src/conn_mux.c
+++ b/src/conn_mux.c
@@ -297,7 +297,7 @@ static juice_agent_t *lookup_agent(conn_registry_t *registry, char *buf, size_t 
 			}
 		}
 
-		if (registry->cb_mux_incoming && msg.use_candidate == 0) {
+		if (registry->cb_mux_incoming) {
 			JLOG_DEBUG("Found STUN request with unknown ICE ufrag");
 			char host[ADDR_MAX_NUMERICHOST_LEN];
 			if (getnameinfo((const struct sockaddr *)&src->addr, src->len, host, ADDR_MAX_NUMERICHOST_LEN, NULL, 0, NI_NUMERICHOST)) {

--- a/src/conn_mux.c
+++ b/src/conn_mux.c
@@ -297,7 +297,7 @@ static juice_agent_t *lookup_agent(conn_registry_t *registry, char *buf, size_t 
 			}
 		}
 
-		if (registry->cb_mux_incoming) {
+		if (registry->cb_mux_incoming && msg.use_candidate == 0) {
 			JLOG_DEBUG("Found STUN request with unknown ICE ufrag");
 			char host[ADDR_MAX_NUMERICHOST_LEN];
 			if (getnameinfo((const struct sockaddr *)&src->addr, src->len, host, ADDR_MAX_NUMERICHOST_LEN, NULL, 0, NI_NUMERICHOST)) {

--- a/src/conn_mux.c
+++ b/src/conn_mux.c
@@ -305,7 +305,7 @@ static juice_agent_t *lookup_agent(conn_registry_t *registry, char *buf, size_t 
 				return NULL;
 			}
 
-			juice_mux_incoming_t incoming_info;
+			juice_mux_binding_request_t incoming_info;
 
 			incoming_info.local_ufrag = local_ufrag;
 			incoming_info.remote_ufrag = separator + 1;

--- a/src/conn_mux.c
+++ b/src/conn_mux.c
@@ -315,7 +315,7 @@ static juice_agent_t *lookup_agent(conn_registry_t *registry, char *buf, size_t 
 
 			binding_info.ufrag = username;
 			binding_info.pwd = separator + 1;
-			binding_info.family = sa->sa_family;
+			binding_info.family = (uint8_t)sa->sa_family;
 			binding_info.address = host;
 			binding_info.port = addr_get_port((struct sockaddr *)src);
 

--- a/src/conn_mux.c
+++ b/src/conn_mux.c
@@ -307,8 +307,8 @@ static juice_agent_t *lookup_agent(conn_registry_t *registry, char *buf, size_t 
 
 			juice_mux_incoming_t incoming_info;
 
-			incoming_info.ufrag = username;
-			incoming_info.pwd = separator + 1;
+			incoming_info.remote_ufrag = username;
+			incoming_info.local_ufrag = separator + 1;
 			incoming_info.address = host;
 			incoming_info.port = addr_get_port((struct sockaddr *)src);
 

--- a/src/conn_mux.c
+++ b/src/conn_mux.c
@@ -507,14 +507,7 @@ void conn_mux_unlock(juice_agent_t *agent) {
 	mutex_unlock(&registry->mutex);
 }
 
-int conn_mux_interrupt(juice_agent_t *agent) {
-	conn_impl_t *conn_impl = agent->conn_impl;
-	conn_registry_t *registry = conn_impl->registry;
-
-	mutex_lock(&registry->mutex);
-	conn_impl->next_timestamp = current_timestamp();
-	mutex_unlock(&registry->mutex);
-
+int conn_mux_interrupt_registry(conn_registry_t *registry) {
 	JLOG_VERBOSE("Interrupting connections thread");
 
 	registry_impl_t *registry_impl = registry->impl;
@@ -528,6 +521,17 @@ int conn_mux_interrupt(juice_agent_t *agent) {
 	}
 	mutex_unlock(&registry_impl->send_mutex);
 	return 0;
+}
+
+int conn_mux_interrupt(juice_agent_t *agent) {
+	conn_impl_t *conn_impl = agent->conn_impl;
+	conn_registry_t *registry = conn_impl->registry;
+
+	mutex_lock(&registry->mutex);
+	conn_impl->next_timestamp = current_timestamp();
+	mutex_unlock(&registry->mutex);
+
+	return conn_mux_interrupt_registry(registry);
 }
 
 int conn_mux_send(juice_agent_t *agent, const addr_record_t *dst, const char *data, size_t size,

--- a/src/conn_mux.c
+++ b/src/conn_mux.c
@@ -319,7 +319,7 @@ static juice_agent_t *lookup_agent(conn_registry_t *registry, char *buf, size_t 
 			binding_info.address = host;
 			binding_info.port = addr_get_port((struct sockaddr *)src);
 
-			registry->cb_stun_binding(&binding_info);
+			registry->cb_stun_binding(&binding_info, registry->stun_binding_user_ptr);
 
 			return NULL;
 		}

--- a/src/conn_mux.c
+++ b/src/conn_mux.c
@@ -307,8 +307,8 @@ static juice_agent_t *lookup_agent(conn_registry_t *registry, char *buf, size_t 
 
 			juice_mux_incoming_t incoming_info;
 
-			incoming_info.remote_ufrag = username;
-			incoming_info.local_ufrag = separator + 1;
+			incoming_info.local_ufrag = local_ufrag;
+			incoming_info.remote_ufrag = separator + 1;
 			incoming_info.address = host;
 			incoming_info.port = addr_get_port((struct sockaddr *)src);
 

--- a/src/conn_mux.h
+++ b/src/conn_mux.h
@@ -24,6 +24,7 @@ int conn_mux_init(juice_agent_t *agent, conn_registry_t *registry, udp_socket_co
 void conn_mux_cleanup(juice_agent_t *agent);
 void conn_mux_lock(juice_agent_t *agent);
 void conn_mux_unlock(juice_agent_t *agent);
+int conn_mux_interrupt_registry(conn_registry_t *registry);
 int conn_mux_interrupt(juice_agent_t *agent);
 int conn_mux_send(juice_agent_t *agent, const addr_record_t *dst, const char *data, size_t size,
                         int ds);


### PR DESCRIPTION
In order to implement WebRTC Direct PeerB, we need to capture STUN requests from unknown clients and return the client's information. Once PeerB receives this information, it will construct the client's SDP and establish a connection with the client on its own.