### PR TITLE
Make error codes more consistent for remote description and candidates

### DIFF
--- a/include/juice/juice.h
+++ b/include/juice/juice.h
@@ -40,6 +40,7 @@ extern "C" {
 #define JUICE_ERR_INVALID -1   // invalid argument
 #define JUICE_ERR_FAILED -2    // runtime error
 #define JUICE_ERR_NOT_AVAIL -3 // element not available
+#define JUICE_ERR_IGNORED -4   // ignored
 
 // ICE Agent
 

--- a/src/juice.c
+++ b/src/juice.c
@@ -54,20 +54,14 @@ JUICE_EXPORT int juice_set_remote_description(juice_agent_t *agent, const char *
 	if (!agent || !sdp)
 		return JUICE_ERR_INVALID;
 
-	if (agent_set_remote_description(agent, sdp) < 0)
-		return JUICE_ERR_FAILED;
-
-	return JUICE_ERR_SUCCESS;
+	return agent_set_remote_description(agent, sdp);
 }
 
 JUICE_EXPORT int juice_add_remote_candidate(juice_agent_t *agent, const char *sdp) {
 	if (!agent || !sdp)
 		return JUICE_ERR_INVALID;
 
-	if (agent_add_remote_candidate(agent, sdp) < 0)
-		return JUICE_ERR_FAILED;
-
-	return JUICE_ERR_SUCCESS;
+	return agent_add_remote_candidate(agent, sdp);
 }
 
 JUICE_EXPORT int juice_add_turn_server(juice_agent_t *agent, const juice_turn_server_t *turn_server) {


### PR DESCRIPTION
This PR makes error codes more consistent for `juice_set_remote_description()` and `juice_add_remote_candidate()`.