### PR TITLE
Fix deadlock on call from user callback in concurrency mode thread

### DIFF
--- a/src/conn_thread.c
+++ b/src/conn_thread.c
@@ -173,7 +173,7 @@ int conn_thread_init(juice_agent_t *agent, conn_registry_t *registry, udp_socket
 		return -1;
 	}
 
-	mutex_init(&conn_impl->mutex, 0);
+	mutex_init(&conn_impl->mutex, MUTEX_RECURSIVE); // Recursive to allow calls from user callbacks
 	mutex_init(&conn_impl->send_mutex, 0);
 
 	agent->conn_impl = conn_impl;
@@ -276,4 +276,3 @@ int conn_thread_get_addrs(juice_agent_t *agent, addr_record_t *records, size_t s
 
 	return udp_get_addrs(conn_impl->sock, records, size);
 }
-

--- a/test/notrickle.c
+++ b/test/notrickle.c
@@ -60,6 +60,7 @@ int test_notrickle() {
 	config2.stun_server_host = "stun.l.google.com";
 	config2.stun_server_port = 19302;
 
+	config2.concurrency_mode = JUICE_CONCURRENCY_MODE_THREAD;
 	config2.cb_state_changed = on_state_changed2;
 	config2.cb_gathering_done = on_gathering_done2;
 	config2.cb_recv = on_recv2;


### PR DESCRIPTION
This PR fixes a deadlock when the user would call an API function from a callback in concurrency mode thread, typically `juice_get_local_description()` from `cb_gathering_done` for non-trickled ICE mode.