### PR TITLE
Add methods to set and get custom data for juice agents

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ source_group("Header Files" FILES "${LIBJUICE_HEADERS}")
 
 set(TESTS_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/test/main.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/agent.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test/crc32.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test/base64.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test/stun.c

--- a/include/juice/juice.h
+++ b/include/juice/juice.h
@@ -113,6 +113,8 @@ JUICE_EXPORT int juice_set_remote_gathering_done(juice_agent_t *agent);
 JUICE_EXPORT int juice_send(juice_agent_t *agent, const char *data, size_t size);
 JUICE_EXPORT int juice_send_diffserv(juice_agent_t *agent, const char *data, size_t size, int ds);
 JUICE_EXPORT juice_state_t juice_get_state(juice_agent_t *agent);
+JUICE_EXPORT void juice_agent_set_data(juice_agent_t *agent, void *data);
+JUICE_EXPORT void* juice_agent_get_data(const juice_agent_t *agent);
 JUICE_EXPORT int juice_get_selected_candidates(juice_agent_t *agent, char *local, size_t local_size,
                                                char *remote, size_t remote_size);
 JUICE_EXPORT int juice_get_selected_addresses(juice_agent_t *agent, char *local, size_t local_size,

--- a/src/agent.c
+++ b/src/agent.c
@@ -145,6 +145,9 @@ juice_agent_t *agent_create(const juice_config_t *config) {
 	// number.
 	juice_random(&agent->ice_tiebreaker, sizeof(agent->ice_tiebreaker));
 
+	// Initially, the agent has no data associated with it
+	agent->user_ptr = NULL;
+
 	return agent;
 
 error:

--- a/src/agent.h
+++ b/src/agent.h
@@ -148,6 +148,11 @@ struct juice_agent {
 
 	thread_t resolver_thread;
 	bool resolver_thread_started;
+
+	/* This is a custom field that can be used to store user data for the agent.
+	 * Use the juice_agent_set_data and juice_agent_get_data methods to store and retrieve the data.
+	 */
+	void* user_ptr;
 };
 
 juice_agent_t *agent_create(const juice_config_t *config);

--- a/src/juice.c
+++ b/src/juice.c
@@ -106,6 +106,20 @@ JUICE_EXPORT int juice_send_diffserv(juice_agent_t *agent, const char *data, siz
 
 JUICE_EXPORT juice_state_t juice_get_state(juice_agent_t *agent) { return agent_get_state(agent); }
 
+JUICE_EXPORT void juice_agent_set_data(juice_agent_t *agent, void *data) {
+	if (agent) {
+		agent->user_ptr = data;
+	}
+}
+
+JUICE_EXPORT void *juice_agent_get_data(const juice_agent_t *agent) {
+	if (agent) {
+		return agent->user_ptr;
+	} else {
+		return NULL;
+	}
+}
+
 JUICE_EXPORT int juice_get_selected_candidates(juice_agent_t *agent, char *local, size_t local_size,
                                                char *remote, size_t remote_size) {
 	if (!agent || (!local && local_size) || (!remote && remote_size))

--- a/test/agent.c
+++ b/test/agent.c
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2020 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "juice/juice.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// This is a custom data structure that will be associated with the agent
+typedef struct {
+	int custom_field1;
+	char custom_field2[256];
+} custom_data_t;
+
+// This function tests the agent data feature (juice_agent_set_data and juice_agent_get_data)
+int test_agent_data() {
+	juice_set_log_level(JUICE_LOG_LEVEL_DEBUG);
+
+	// Create a basic agent with default configuration
+	juice_config_t *juiceConfig = malloc(sizeof(juice_config_t));
+	if (!juiceConfig) {
+		return -1;
+	}
+
+	memset(juiceConfig, 0, sizeof(*juiceConfig));
+	juiceConfig->stun_server_host = "stun.l.google.com";
+	juiceConfig->stun_server_port = 19302;
+
+	juice_agent_t *agent = juice_create(juiceConfig);
+	if (!agent) {
+		fprintf(stderr, "Failed to create agent\n");
+		free(juiceConfig);
+		return -1;
+	}
+
+	// Allocate and set custom data
+	custom_data_t *customData = malloc(sizeof(custom_data_t));
+	if (!customData) {
+		fprintf(stderr, "Failed to allocate custom data\n");
+		juice_destroy(agent);
+		free(juiceConfig);
+		return -1;
+	}
+	customData->custom_field1 = 42;
+	strcpy(customData->custom_field2, "Hello, World!");
+
+	// Ensure that get_data returns NULL before set_data
+	if (juice_agent_get_data(agent) != NULL) {
+		fprintf(stderr, "get_data should return NULL before set_data\n");
+		free(customData);
+		juice_destroy(agent);
+		free(juiceConfig);
+		return -1;
+	}
+
+	juice_agent_set_data(agent, customData);
+
+	// Retrieve custom data
+	const custom_data_t *retrievedData = (custom_data_t*)juice_agent_get_data(agent);
+	if (!retrievedData) {
+		fprintf(stderr, "Failed to retrieve custom data\n");
+		free(customData);
+		juice_destroy(agent);
+		free(juiceConfig);
+		return -1;
+	}
+
+	// Validate custom data
+	if (retrievedData->custom_field1 != 42 || strcmp(retrievedData->custom_field2, "Hello, World!") != 0) {
+		fprintf(stderr, "Custom data validation failed\n");
+		free(customData);
+		juice_destroy(agent);
+		free(juiceConfig);
+		return -1;
+	}
+
+	// Clean up
+	free(customData);
+	juice_destroy(agent);
+	free(juiceConfig);
+
+	// If all tests passed, return 0
+	return 0;
+}

--- a/test/main.c
+++ b/test/main.c
@@ -10,6 +10,7 @@
 
 #include <stdio.h>
 
+int test_agent_data(void);
 int test_crc32(void);
 int test_base64(void);
 int test_stun(void);
@@ -29,6 +30,12 @@ int test_server(void);
 
 int main(int argc, char **argv) {
 	juice_set_log_level(JUICE_LOG_LEVEL_WARN);
+
+	printf("\nRunning agent data test...\n");
+	if (test_agent_data()) {
+		fprintf(stderr, "Agent data test failed\n");
+		return -1;
+	}
 
 	printf("\nRunning CRC32 implementation test...\n");
 	if (test_crc32()) {


### PR DESCRIPTION
- Implemented juice_agent_set_data to allow users to attach custom data to a juice agent.
- Implemented juice_agent_get_data to retrieve the custom data attached to a juice agent.
- Updated juice_agent_t structure to include a user_ptr for storing custom data.
- Added tests to validate the functionality of the new methods.

These changes enable each juice agent to have its own custom data, enhancing flexibility and usability.