### PR TITLE
Prevent passing NULL buffer to sendto() for better compatibility with C standard libraries

### DIFF
--- a/src/conn_mux.c
+++ b/src/conn_mux.c
@@ -491,7 +491,8 @@ int conn_mux_interrupt(juice_agent_t *agent) {
 
 	registry_impl_t *registry_impl = registry->impl;
 	mutex_lock(&registry_impl->send_mutex);
-	if (udp_sendto_self(registry_impl->sock, NULL, 0) < 0) {
+	char dummy = 0; // Some C libraries might error out on NULL pointers
+	if (udp_sendto_self(registry_impl->sock, &dummy, 0) < 0) {
 		if (sockerrno != SEAGAIN && sockerrno != SEWOULDBLOCK) {
 			JLOG_WARN("Failed to interrupt poll by triggering socket, errno=%d", sockerrno);
 		}

--- a/src/conn_poll.c
+++ b/src/conn_poll.c
@@ -377,15 +377,15 @@ int conn_poll_interrupt(juice_agent_t *agent) {
 
 	JLOG_VERBOSE("Interrupting connections thread");
 
+	char dummy = 0;
 #ifdef _WIN32
-	if (udp_sendto_self(registry_impl->interrupt_sock, NULL, 0) < 0) {
+	if (udp_sendto_self(registry_impl->interrupt_sock, &dummy, 0) < 0) {
 		if (sockerrno != SEAGAIN && sockerrno != SEWOULDBLOCK) {
 			JLOG_WARN("Failed to interrupt poll by triggering socket, errno=%d", sockerrno);
 		}
 		return -1;
 	}
 #else
-	char dummy = 0;
 	if (write(registry_impl->interrupt_pipe_out, &dummy, 1) < 0 && errno != EAGAIN &&
 	    errno != EWOULDBLOCK) {
 		JLOG_WARN("Failed to interrupt poll by writing to pipe, errno=%d", errno);

--- a/src/conn_thread.c
+++ b/src/conn_thread.c
@@ -229,7 +229,8 @@ int conn_thread_interrupt(juice_agent_t *agent) {
 	JLOG_VERBOSE("Interrupting connection thread");
 
 	mutex_lock(&conn_impl->send_mutex);
-	if (udp_sendto_self(conn_impl->sock, NULL, 0) < 0) {
+	char dummy = 0; // Some C libraries might error out on NULL pointers
+	if (udp_sendto_self(conn_impl->sock, &dummy, 0) < 0) {
 		if (sockerrno != SEAGAIN && sockerrno != SEWOULDBLOCK) {
 			JLOG_WARN("Failed to interrupt poll by triggering socket, errno=%d", sockerrno);
 		}

--- a/src/server.c
+++ b/src/server.c
@@ -557,7 +557,8 @@ int server_interrupt(juice_server_t *server) {
 		return -1;
 	}
 
-	if (udp_sendto_self(server->sock, NULL, 0) < 0) {
+	char dummy = 0; // Some C libraries might error out on NULL pointers
+	if (udp_sendto_self(server->sock, &dummy, 0) < 0) {
 		if (sockerrno != SEAGAIN && sockerrno != SEWOULDBLOCK) {
 			JLOG_WARN("Failed to interrupt thread by triggering socket, errno=%d", sockerrno);
 			mutex_unlock(&server->mutex);


### PR DESCRIPTION
Should fix https://github.com/paullouisageneau/libjuice/issues/269