### PR TITLE
Fix ret < 0  && ret == 10038L is never possible

### DIFF
--- a/src/conn_poll.c
+++ b/src/conn_poll.c
@@ -301,7 +301,7 @@ int conn_poll_run(conn_registry_t *registry) {
 		JLOG_VERBOSE("Leaving poll");
 		if (ret < 0) {
 #ifdef _WIN32
-			if (ret == WSAENOTSOCK)
+			if (sockerrno == WSAENOTSOCK)
 				continue; // prepare again as the fd has been removed
 #endif
 			if (sockerrno == SEINTR || sockerrno == SEAGAIN) {


### PR DESCRIPTION
This is related to https://github.com/paullouisageneau/libdatachannel/issues/1252
I did test this locally and it seems to be working as expected now