### PR TITLE
CMake: Comply with BUILD_SHARED_LIBS option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project (libjuice
 	LANGUAGES C)
 set(PROJECT_DESCRIPTION "UDP Interactive Connectivity Establishment (ICE) library")
 
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(USE_NETTLE "Use Nettle for hash functions" OFF)
 option(NO_SERVER "Disable server support" OFF)
 option(NO_TESTS "Disable tests build" OFF)
@@ -89,7 +90,7 @@ source_group("Fuzzer Files" FILES "${FUZZER_SOURCES}")
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
-add_library(juice SHARED ${LIBJUICE_SOURCES})
+add_library(juice ${LIBJUICE_SOURCES})
 set_target_properties(juice PROPERTIES VERSION ${PROJECT_VERSION})
 target_include_directories(juice PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>


### PR DESCRIPTION
Setting `BUILD_SHARED_LIBS` to `OFF` now builds the `LibJuice::LibJuice` target statically.