### PR TITLE
Add an API to provide a way to get errno of juice_send

### DIFF
--- a/include/juice/juice.h
+++ b/include/juice/juice.h
@@ -111,6 +111,7 @@ JUICE_EXPORT int juice_add_remote_candidate(juice_agent_t *agent, const char *sd
 JUICE_EXPORT int juice_add_turn_server(juice_agent_t *agent, const juice_turn_server_t *turn_server);
 JUICE_EXPORT int juice_set_remote_gathering_done(juice_agent_t *agent);
 JUICE_EXPORT int juice_send(juice_agent_t *agent, const char *data, size_t size);
+JUICE_EXPORT int juice_send_detailed(juice_agent_t *agent, const char *data, size_t size, int* ret);
 JUICE_EXPORT int juice_send_diffserv(juice_agent_t *agent, const char *data, size_t size, int ds);
 JUICE_EXPORT juice_state_t juice_get_state(juice_agent_t *agent);
 JUICE_EXPORT int juice_get_selected_candidates(juice_agent_t *agent, char *local, size_t local_size,

--- a/src/agent.c
+++ b/src/agent.c
@@ -1683,7 +1683,7 @@ int agent_send_stun_binding(juice_agent_t *agent, agent_stun_entry_t *entry, stu
 	// Direct send
 	int ret = agent_direct_send(agent, &entry->record, buffer, size, 0);
 	if (ret < 0) {
-		if (ret == SENETUNREACH)
+		if (ret == -SENETUNREACH)
 			JLOG_INFO("STUN binding failed: Network unreachable");
 		else
 			JLOG_WARN("STUN message send failed");

--- a/src/conn_mux.c
+++ b/src/conn_mux.c
@@ -522,6 +522,7 @@ int conn_mux_send(juice_agent_t *agent, const addr_record_t *dst, const char *da
 
 	int ret = udp_sendto(registry_impl->sock, data, size, dst);
 	if (ret < 0) {
+		ret = -sockerrno;
 		if (sockerrno == SEAGAIN || sockerrno == SEWOULDBLOCK)
 			JLOG_INFO("Send failed, buffer is full");
 		else if (sockerrno == SEMSGSIZE)

--- a/src/conn_poll.c
+++ b/src/conn_poll.c
@@ -412,6 +412,7 @@ int conn_poll_send(juice_agent_t *agent, const addr_record_t *dst, const char *d
 
 	int ret = udp_sendto(conn_impl->sock, data, size, dst);
 	if (ret < 0) {
+		ret = -sockerrno;
 		if (sockerrno == SEAGAIN || sockerrno == SEWOULDBLOCK)
 			JLOG_INFO("Send failed, buffer is full");
 		else if (sockerrno == SEMSGSIZE)

--- a/src/conn_thread.c
+++ b/src/conn_thread.c
@@ -260,6 +260,7 @@ int conn_thread_send(juice_agent_t *agent, const addr_record_t *dst, const char 
 
 	int ret = udp_sendto(conn_impl->sock, data, size, dst);
 	if (ret < 0) {
+		ret = -sockerrno;
 		if (sockerrno == SEAGAIN || sockerrno == SEWOULDBLOCK)
 			JLOG_INFO("Send failed, buffer is full");
 		else if (sockerrno == SEMSGSIZE)

--- a/src/juice.c
+++ b/src/juice.c
@@ -85,11 +85,18 @@ JUICE_EXPORT int juice_set_remote_gathering_done(juice_agent_t *agent) {
 }
 
 JUICE_EXPORT int juice_send(juice_agent_t *agent, const char *data, size_t size) {
+	int ret;
+	return juice_send_detailed(agent, data, size, &ret);
+}
+
+JUICE_EXPORT int juice_send_detailed(juice_agent_t *agent, const char *data, size_t size, int *ret) {
 	if (!agent || (!data && size))
 		return JUICE_ERR_INVALID;
 
-	if (agent_send(agent, data, size, 0) < 0)
+	*ret = agent_send(agent, data, size, 0);
+	if (*ret < 0) {
 		return JUICE_ERR_FAILED;
+	}
 
 	return JUICE_ERR_SUCCESS;
 }


### PR DESCRIPTION
The goal of this PR is to allow users to get the failure reason of juice_send.
juice_send only tells whether the transmission failed or not.
However, sometimes knowing the failure reason can help to fix it.

For example, It would be helpful to be able to do like this:
```
if(juice_send(...) != JUICE_ERR_SUCCESS) {
    if(errno==EAGAIN) ... // retry later
    if(errno==EMSGSIZE) ... // tell user to make packets smaller
    ...
}
```