### PR TITLE
Fix intensive CPU usage when DISABLE_CONSENT_FRESHNESS=ON

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -1140,9 +1140,13 @@ int agent_bookkeeping(juice_agent_t *agent, timestamp_t *next_timestamp) {
 		if (entry->next_transmission && *next_timestamp > entry->next_transmission)
 			*next_timestamp = entry->next_transmission;
 
+#if JUICE_DISABLE_CONSENT_FRESHNESS
+		// No expiration
+#else
 		if (entry->state == AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE && entry->pair &&
 		    *next_timestamp > entry->pair->consent_expiry)
 			*next_timestamp = selected_pair->consent_expiry;
+#endif
 	}
 
 	return 0;


### PR DESCRIPTION
This PR fixes incorrect scheduling leading to intensive CPU usage when `DISABLE_CONSENT_FRESHNESS=ON`.