### PR TITLE
feat: expose juice_mux_stop_listen function

### DIFF
--- a/include/juice/juice.h
+++ b/include/juice/juice.h
@@ -132,6 +132,7 @@ JUICE_EXPORT int juice_get_selected_addresses(juice_agent_t *agent, char *local,
 JUICE_EXPORT int juice_set_local_ice_attributes(juice_agent_t *agent, const char *ufrag, const char *pwd);
 JUICE_EXPORT const char *juice_state_to_string(juice_state_t state);
 JUICE_EXPORT int juice_mux_listen(const char *bind_address, int local_port, juice_cb_mux_incoming_t cb, void *user_ptr);
+JUICE_EXPORT int juice_mux_stop_listen(const char *bind_address, int local_port);
 
 // ICE server
 

--- a/src/conn.c
+++ b/src/conn.c
@@ -256,7 +256,7 @@ int conn_get_addrs(juice_agent_t *agent, addr_record_t *records, size_t size) {
 	return get_mode_entry(agent)->get_addrs_func(agent, records, size);
 }
 
-static int juice_mux_stop_listen(const char *bind_address, int local_port) {
+int juice_mux_stop_listen(const char *bind_address, int local_port) {
     (void)bind_address;
     (void)local_port;
 


### PR DESCRIPTION
This is a follow-up to #248 that just adds the `juice_mux_stop_listen` function to `juice.h` in order to invoke it from libdatachannel.