### PR TITLE
feat: allow specifying initial ice mode

### DIFF
--- a/include/juice/juice.h
+++ b/include/juice/juice.h
@@ -61,6 +61,12 @@ typedef enum juice_state {
 	JUICE_STATE_FAILED
 } juice_state_t;
 
+typedef enum juice_ice_mode {
+	JUICE_ICE_MODE_UNKNOWN,
+	JUICE_ICE_MODE_CONTROLLED,
+	JUICE_ICE_MODE_CONTROLLING
+} juice_ice_mode_t;
+
 typedef void (*juice_cb_state_changed_t)(juice_agent_t *agent, juice_state_t state, void *user_ptr);
 typedef void (*juice_cb_candidate_t)(juice_agent_t *agent, const char *sdp, void *user_ptr);
 typedef void (*juice_cb_gathering_done_t)(juice_agent_t *agent, void *user_ptr);
@@ -129,7 +135,7 @@ JUICE_EXPORT int juice_get_selected_candidates(juice_agent_t *agent, char *local
                                                char *remote, size_t remote_size);
 JUICE_EXPORT int juice_get_selected_addresses(juice_agent_t *agent, char *local, size_t local_size,
                                               char *remote, size_t remote_size);
-JUICE_EXPORT int juice_set_local_ice_attributes(juice_agent_t *agent, const char *ufrag, const char *pwd);
+JUICE_EXPORT int juice_set_local_ice_attributes(juice_agent_t *agent, const char *ufrag, const char *pwd, juice_ice_mode_t ice_mode);
 JUICE_EXPORT const char *juice_state_to_string(juice_state_t state);
 JUICE_EXPORT int juice_mux_listen(const char *bind_address, int local_port, juice_cb_mux_incoming_t cb, void *user_ptr);
 

--- a/src/agent.h
+++ b/src/agent.h
@@ -74,12 +74,6 @@
 
 #define AGENT_TURN_MAP_SIZE ICE_MAX_CANDIDATES_COUNT
 
-typedef enum agent_mode {
-	AGENT_MODE_UNKNOWN,
-	AGENT_MODE_CONTROLLED,
-	AGENT_MODE_CONTROLLING
-} agent_mode_t;
-
 typedef enum agent_stun_entry_type {
 	AGENT_STUN_ENTRY_TYPE_EMPTY,
 	AGENT_STUN_ENTRY_TYPE_SERVER,
@@ -105,7 +99,7 @@ typedef struct agent_turn_state {
 typedef struct agent_stun_entry {
 	agent_stun_entry_type_t type;
 	agent_stun_entry_state_t state;
-	agent_mode_t mode;
+	juice_ice_mode_t mode;
 	ice_candidate_pair_t *pair;
 	addr_record_t record;
 	addr_record_t relayed;
@@ -125,7 +119,7 @@ typedef struct agent_stun_entry {
 struct juice_agent {
 	juice_config_t config;
 	juice_state_t state;
-	agent_mode_t mode;
+	juice_ice_mode_t mode;
 
 	ice_description_t local;
 	ice_description_t remote;
@@ -159,7 +153,7 @@ int agent_resolve_servers(juice_agent_t *agent);
 int agent_get_local_description(juice_agent_t *agent, char *buffer, size_t size);
 int agent_set_remote_description(juice_agent_t *agent, const char *sdp);
 int agent_add_remote_candidate(juice_agent_t *agent, const char *sdp);
-int agent_set_local_ice_attributes(juice_agent_t *agent, const char *ufrag, const char *pwd);
+int agent_set_local_ice_attributes(juice_agent_t *agent, const char *ufrag, const char *pwd, juice_ice_mode_t ice_mode);
 int agent_add_turn_server(juice_agent_t *agent, const juice_turn_server_t *turn_server);
 int agent_set_remote_gathering_done(juice_agent_t *agent);
 int agent_send(juice_agent_t *agent, const char *data, size_t size, int ds);

--- a/src/juice.c
+++ b/src/juice.c
@@ -140,12 +140,12 @@ JUICE_EXPORT int juice_get_selected_addresses(juice_agent_t *agent, char *local,
 	return JUICE_ERR_SUCCESS;
 }
 
-int juice_set_local_ice_attributes(juice_agent_t *agent, const char *ufrag, const char *pwd)
+int juice_set_local_ice_attributes(juice_agent_t *agent, const char *ufrag, const char *pwd, juice_ice_mode_t ice_mode)
 {
 	if (!ufrag || !pwd)
 		return JUICE_ERR_INVALID;
 
-	return agent_set_local_ice_attributes(agent, ufrag, pwd);
+	return agent_set_local_ice_attributes(agent, ufrag, pwd, ice_mode);
 }
 
 JUICE_EXPORT const char *juice_state_to_string(juice_state_t state) {

--- a/test/ufrag.c
+++ b/test/ufrag.c
@@ -7,6 +7,7 @@
  */
 
 #include "juice/juice.h"
+#include "agent.h"
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -26,29 +27,32 @@ int test_ufrag() {
 
 	agent = juice_create(&config);
 
-	if (juice_set_local_ice_attributes(agent, NULL, NULL) != JUICE_ERR_INVALID)
+	if (juice_set_local_ice_attributes(agent, NULL, NULL, 0) != JUICE_ERR_INVALID)
 		success = false;
 
-	if (juice_set_local_ice_attributes(agent, "ufrag", NULL) != JUICE_ERR_INVALID)
+	if (juice_set_local_ice_attributes(agent, "ufrag", NULL, 0) != JUICE_ERR_INVALID)
 		success = false;
 
-	if (juice_set_local_ice_attributes(agent, NULL, "pw01234567890123456789") != JUICE_ERR_INVALID)
+	if (juice_set_local_ice_attributes(agent, NULL, "pw01234567890123456789", 0) != JUICE_ERR_INVALID)
 		success = false;
 
-	if (juice_set_local_ice_attributes(agent, "ufrag", "pw0123456789012345678") != JUICE_ERR_INVALID)
+	if (juice_set_local_ice_attributes(agent, "ufrag", "pw0123456789012345678", 0) != JUICE_ERR_INVALID)
 		success = false;
 
-	if (juice_set_local_ice_attributes(agent, "usr", "pw01234567890123456789") != JUICE_ERR_INVALID)
+	if (juice_set_local_ice_attributes(agent, "usr", "pw01234567890123456789", 0) != JUICE_ERR_INVALID)
 		success = false;
 
-	if (juice_set_local_ice_attributes(agent, "ufrag:", "pw01234567890123456789") != JUICE_ERR_INVALID)
+	if (juice_set_local_ice_attributes(agent, "ufrag:", "pw01234567890123456789", 0) != JUICE_ERR_INVALID)
 		success = false;
 
-	if (juice_set_local_ice_attributes(agent, "ufrag", "pw0123456789012345678?") != JUICE_ERR_INVALID)
+	if (juice_set_local_ice_attributes(agent, "ufrag", "pw0123456789012345678?", 0) != JUICE_ERR_INVALID)
+		success = false;
+
+	if (agent->mode != JUICE_ICE_MODE_UNKNOWN)
 		success = false;
 
 	// Set local ICE attributes
-	juice_set_local_ice_attributes(agent, "ufrag", "pw01234567890123456789");
+	juice_set_local_ice_attributes(agent, "ufrag", "pw01234567890123456789", JUICE_ICE_MODE_CONTROLLED);
 
 	// Generate local description
 	char sdp[JUICE_MAX_SDP_STRING_LEN];
@@ -59,6 +63,9 @@ int test_ufrag() {
 		success = false;
 
 	if (strstr(sdp, "a=ice-pwd:pw01234567890123456789\r\n") == NULL)
+		success = false;
+
+	if (agent->mode != JUICE_ICE_MODE_CONTROLLED)
 		success = false;
 
 	// Destroy


### PR DESCRIPTION
RFC 8445 6.1.1 says:

> The initiating agent that started the ICE processing MUST take the controlling role, and the other MUST take the controlled role.

The spec also shows how to resolve conflicts when both agents are in the controlling role.

From what I can see here, libjuice will always start in controlling mode and try to resolve the conflict before contining but it appears some implementations [don't support that](https://github.com/pion/ice/issues/359#issuecomment-2610300555) so one agent has to start in controlled role.

The change here is to allow passing the role to `juice_set_local_ice_attributes` in order to start the receiving agent off in the controlled role.