### PR TITLE
fix: set hash_reset before invoking it

### DIFF
--- a/src/picohash.h
+++ b/src/picohash.h
@@ -729,7 +729,7 @@ inline void picohash_init_hmac(picohash_ctx_t *ctx, void (*initf)(picohash_ctx_t
         /* hash the key if it is too long */
         picohash_update(ctx, key, key_len);
         picohash_final(ctx, ctx->_hmac.key);
-		ctx->_hmac.hash_reset = ctx->_reset;
+        ctx->_hmac.hash_reset = ctx->_reset;
         ctx->_hmac.hash_reset(ctx);
     } else {
         memcpy(ctx->_hmac.key, key, key_len);

--- a/src/picohash.h
+++ b/src/picohash.h
@@ -729,6 +729,7 @@ inline void picohash_init_hmac(picohash_ctx_t *ctx, void (*initf)(picohash_ctx_t
         /* hash the key if it is too long */
         picohash_update(ctx, key, key_len);
         picohash_final(ctx, ctx->_hmac.key);
+		ctx->_hmac.hash_reset = ctx->_reset;
         ctx->_hmac.hash_reset(ctx);
     } else {
         memcpy(ctx->_hmac.key, key, key_len);

--- a/src/picohash.h
+++ b/src/picohash.h
@@ -729,8 +729,7 @@ inline void picohash_init_hmac(picohash_ctx_t *ctx, void (*initf)(picohash_ctx_t
         /* hash the key if it is too long */
         picohash_update(ctx, key, key_len);
         picohash_final(ctx, ctx->_hmac.key);
-        ctx->_hmac.hash_reset = ctx->_reset;
-        ctx->_hmac.hash_reset(ctx);
+        picohash_reset(ctx);
     } else {
         memcpy(ctx->_hmac.key, key, key_len);
     }


### PR DESCRIPTION
Otherwise any connection attempt with a ufrag longer than 64 characters causes the process to exit with a SIGBUS error.

I have not been able to isolate this into a test, but at runtime it crashes the remote process every single time.