### PR TITLE
Prevent connectivity lost on non symmetric address

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -1078,6 +1078,7 @@ int agent_bookkeeping(juice_agent_t *agent, timestamp_t *next_timestamp) {
 			    nominated_entry->state != AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE) {
 				nominated_entry->state = AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE;
 				agent_arm_keepalive(agent, nominated_entry);
+				atomic_store(&agent->selected_entry, nominated_entry); // for consistency
 			}
 
 			// If the entry of the nominated candidate is relayed locally, we need also to

--- a/src/agent.c
+++ b/src/agent.c
@@ -1467,21 +1467,20 @@ int agent_process_stun_binding(juice_agent_t *agent, const stun_message_t *msg,
 				return -1;
 			}
 
-			// 7.2.5.2.1. Non-Symmetric Transport Addresses:
-			// The ICE agent MUST check that the source and destination transport addresses in the
-			// Binding request and response are symmetric. [...] If the addresses are not symmetric,
-			// the agent MUST set the candidate pair state to Failed.
-			if (!addr_record_is_equal(src, &entry->record, true)) {
-				JLOG_DEBUG(
-				    "Candidate pair check failed (non-symmetric source address in response)");
-				entry->state = AGENT_STUN_ENTRY_STATE_FAILED;
-				entry->next_transmission = 0;
-				if (pair)
-					pair->state = ICE_CANDIDATE_PAIR_STATE_FAILED;
-				break;
-			}
-
 			if (pair->state != ICE_CANDIDATE_PAIR_STATE_SUCCEEDED) {
+				// 7.2.5.2.1. Non-Symmetric Transport Addresses:
+				// The ICE agent MUST check that the source and destination transport addresses in
+				// the Binding request and response are symmetric. [...] If the addresses are not
+				// symmetric, the agent MUST set the candidate pair state to Failed.
+				if (!addr_record_is_equal(src, &entry->record, true)) {
+					JLOG_DEBUG(
+					    "Candidate pair check failed (non-symmetric source address in response)");
+					entry->state = AGENT_STUN_ENTRY_STATE_FAILED;
+					entry->next_transmission = 0;
+					pair->state = ICE_CANDIDATE_PAIR_STATE_FAILED;
+					break;
+				}
+
 				JLOG_DEBUG("Candidate pair check succeeded");
 				pair->state = ICE_CANDIDATE_PAIR_STATE_SUCCEEDED;
 			}


### PR DESCRIPTION
This PR prevents failure when the binding response has non symmetric address after the initial check. It also ensures `selected_entry` stays consistent even if the nominated pair changes state.

This should mitigate issue https://github.com/paullouisageneau/libjuice/issues/304 with macOS.