### PR TITLE
set AI_ADDRCONF hint only if exists

### DIFF
--- a/src/addr.c
+++ b/src/addr.c
@@ -258,7 +258,9 @@ int addr_resolve(const char *hostname, const char *service, int socktype, addr_r
 	hints.ai_family = AF_UNSPEC;
 	hints.ai_socktype = socktype;
 	hints.ai_protocol = socktype == SOCK_STREAM ? IPPROTO_TCP : IPPROTO_UDP;
+#ifdef AI_ADDRCONFIG
 	hints.ai_flags = AI_ADDRCONFIG;
+#endif
 	struct addrinfo *ai_list = NULL;
 	if (getaddrinfo(hostname, service, &hints, &ai_list)) {
 		JLOG_WARN("Address resolution failed for %s:%s", hostname, service);

--- a/src/ice.c
+++ b/src/ice.c
@@ -205,7 +205,9 @@ int ice_resolve_candidate(ice_candidate_t *candidate, ice_resolve_mode_t mode) {
 		hints.ai_socktype = SOCK_DGRAM;
 		hints.ai_protocol = IPPROTO_UDP;
 	}
+#ifdef AI_ADDRCONFIG
 	hints.ai_flags = AI_ADDRCONFIG;
+#endif
 	if (mode != ICE_RESOLVE_MODE_LOOKUP)
 		hints.ai_flags |= AI_NUMERICHOST | AI_NUMERICSERV;
 	struct addrinfo *ai_list = NULL;


### PR DESCRIPTION
This PR improves cross-platform compatibility by conditionally using the AI_ADDRCONFIG flag only when it's available on the target system.

**What Changed**

- Added conditional compilation guards (#ifdef AI_ADDRCONFIG) around AI_ADDRCONFIG usage in src/addr.c and src/ice.c
- This ensures the code compiles and runs correctly on systems that don't define this flag (like QNX)

**Why This Matters**

The AI_ADDRCONFIG flag isn't universally available across all platforms. Without these guards, compilation would fail on systems like QNX that don't provide this flag.