### PR TITLE
#61 Add Differentiated Services on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,30 +66,30 @@ set(LIBJUICE_HEADERS
 source_group("Header Files" FILES "${LIBJUICE_HEADERS}")
 
 set(TESTS_SOURCES
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/main.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/crc32.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/base64.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/stun-unhandled.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/stun-unhandled-multiple.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/stun-unhandled-no-host.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/stun-unhandled-unhandle.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/stun.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/gathering.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/connectivity.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/turn.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/thread.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/mux.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/notrickle.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/server.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/conflict.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/bind.c
+	${CMAKE_CURRENT_SOURCE_DIR}/test/main.c
+	${CMAKE_CURRENT_SOURCE_DIR}/test/crc32.c
+	${CMAKE_CURRENT_SOURCE_DIR}/test/base64.c
+	${CMAKE_CURRENT_SOURCE_DIR}/test/stun-unhandled.c
+	${CMAKE_CURRENT_SOURCE_DIR}/test/stun-unhandled-multiple.c
+	${CMAKE_CURRENT_SOURCE_DIR}/test/stun-unhandled-no-host.c
+	${CMAKE_CURRENT_SOURCE_DIR}/test/stun-unhandled-unhandle.c
+	${CMAKE_CURRENT_SOURCE_DIR}/test/stun.c
+	${CMAKE_CURRENT_SOURCE_DIR}/test/gathering.c
+	${CMAKE_CURRENT_SOURCE_DIR}/test/connectivity.c
+	${CMAKE_CURRENT_SOURCE_DIR}/test/turn.c
+	${CMAKE_CURRENT_SOURCE_DIR}/test/thread.c
+	${CMAKE_CURRENT_SOURCE_DIR}/test/mux.c
+	${CMAKE_CURRENT_SOURCE_DIR}/test/notrickle.c
+	${CMAKE_CURRENT_SOURCE_DIR}/test/server.c
+	${CMAKE_CURRENT_SOURCE_DIR}/test/conflict.c
+	${CMAKE_CURRENT_SOURCE_DIR}/test/bind.c
 	${CMAKE_CURRENT_SOURCE_DIR}/test/ufrag.c
 	${CMAKE_CURRENT_SOURCE_DIR}/test/tcp.c
 )
 source_group("Test Files" FILES "${TESTS_SOURCES}")
 
 set(FUZZER_SOURCES
-    ${CMAKE_CURRENT_SOURCE_DIR}/fuzzer/fuzzer.c
+	${CMAKE_CURRENT_SOURCE_DIR}/fuzzer/fuzzer.c
 )
 source_group("Fuzzer Files" FILES "${FUZZER_SOURCES}")
 
@@ -99,8 +99,8 @@ find_package(Threads REQUIRED)
 add_library(juice ${LIBJUICE_SOURCES})
 set_target_properties(juice PROPERTIES VERSION ${PROJECT_VERSION})
 target_include_directories(juice PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>)
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+	$<INSTALL_INTERFACE:include>)
 target_include_directories(juice PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/juice)
 target_include_directories(juice PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_compile_definitions(juice PRIVATE $<$<CONFIG:Release>:RELEASE=1>)
@@ -109,8 +109,8 @@ target_link_libraries(juice PRIVATE Threads::Threads)
 add_library(juice-static STATIC EXCLUDE_FROM_ALL ${LIBJUICE_SOURCES})
 set_target_properties(juice-static PROPERTIES VERSION ${PROJECT_VERSION})
 target_include_directories(juice-static PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>)
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+	$<INSTALL_INTERFACE:include>)
 target_include_directories(juice-static PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/juice)
 target_include_directories(juice-static PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_compile_definitions(juice-static PRIVATE $<$<CONFIG:Release>:RELEASE=1>)
@@ -129,13 +129,13 @@ endif()
 
 if (USE_NETTLE)
 	find_package(Nettle REQUIRED)
-    target_compile_definitions(juice PRIVATE USE_NETTLE=1)
-    target_link_libraries(juice PRIVATE Nettle::Nettle)
-    target_compile_definitions(juice-static PRIVATE USE_NETTLE=1)
-    target_link_libraries(juice-static PRIVATE Nettle::Nettle)
+	target_compile_definitions(juice PRIVATE USE_NETTLE=1)
+	target_link_libraries(juice PRIVATE Nettle::Nettle)
+	target_compile_definitions(juice-static PRIVATE USE_NETTLE=1)
+	target_link_libraries(juice-static PRIVATE Nettle::Nettle)
 else()
-    target_compile_definitions(juice PRIVATE USE_NETTLE=0)
-    target_compile_definitions(juice-static PRIVATE USE_NETTLE=0)
+	target_compile_definitions(juice PRIVATE USE_NETTLE=0)
+	target_compile_definitions(juice-static PRIVATE USE_NETTLE=0)
 endif()
 
 if (NO_SERVER)
@@ -173,22 +173,22 @@ install(
 
 include(CMakePackageConfigHelpers)
 configure_package_config_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/LibJuiceConfig.cmake.in
-    ${CMAKE_BINARY_DIR}/LibJuiceConfig.cmake
-    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/LibJuice
-    NO_SET_AND_CHECK_MACRO
-    NO_CHECK_REQUIRED_COMPONENTS_MACRO
+	${CMAKE_CURRENT_SOURCE_DIR}/cmake/LibJuiceConfig.cmake.in
+	${CMAKE_BINARY_DIR}/LibJuiceConfig.cmake
+	INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/LibJuice
+	NO_SET_AND_CHECK_MACRO
+	NO_CHECK_REQUIRED_COMPONENTS_MACRO
 )
 write_basic_package_version_file(
-    ${CMAKE_BINARY_DIR}/LibJuiceConfigVersion.cmake
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY SameMajorVersion
+	${CMAKE_BINARY_DIR}/LibJuiceConfigVersion.cmake
+	VERSION ${PROJECT_VERSION}
+	COMPATIBILITY SameMajorVersion
 )
 # Export config and version files
 install(FILES
 	${CMAKE_BINARY_DIR}/LibJuiceConfig.cmake
 	${CMAKE_BINARY_DIR}/LibJuiceConfigVersion.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/LibJuice)
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/LibJuice)
 
 set_target_properties(juice PROPERTIES C_VISIBILITY_PRESET hidden)
 target_compile_definitions(juice PRIVATE JUICE_EXPORTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,10 +119,12 @@ target_link_libraries(juice-static PRIVATE Threads::Threads)
 if(WIN32)
 	target_link_libraries(juice PRIVATE
 		ws2_32 # winsock2
-		bcrypt)
+		bcrypt
+		qwave) # qWave API
 	target_link_libraries(juice-static PRIVATE
 		ws2_32 # winsock2
-		bcrypt)
+		bcrypt
+		qwave) # qWave API
 endif()
 
 if (USE_NETTLE)
@@ -242,7 +244,7 @@ if(NOT NO_TESTS)
 	target_link_libraries(juice-tests juice Threads::Threads)
 
 	if(WIN32)
-		target_link_libraries(juice-tests ws2_32)
+		target_link_libraries(juice-tests ws2_32 qwave)
 	endif()
 endif()
 

--- a/src/agent.h
+++ b/src/agent.h
@@ -153,6 +153,10 @@ struct juice_agent {
 
 	thread_t resolver_thread;
 	bool resolver_thread_started;
+
+#ifdef _WIN32
+	HANDLE qos_handle;
+#endif
 };
 
 juice_agent_t *agent_create(const juice_config_t *config);

--- a/src/conn_mux.c
+++ b/src/conn_mux.c
@@ -625,7 +625,11 @@ int conn_mux_send(juice_agent_t *agent, const addr_record_t *dst, const char *da
 
 	if (registry_impl->send_ds >= 0 && registry_impl->send_ds != ds) {
 		JLOG_VERBOSE("Setting Differentiated Services field to 0x%X", ds);
+#ifdef _WIN32
+		if (udp_set_diffserv_qwave(registry_impl->sock, ds, agent) == 0)
+#else
 		if (udp_set_diffserv(registry_impl->sock, ds) == 0)
+#endif
 			registry_impl->send_ds = ds;
 		else
 			registry_impl->send_ds = -1; // disable for next time

--- a/src/conn_poll.c
+++ b/src/conn_poll.c
@@ -624,7 +624,11 @@ int conn_poll_send(juice_agent_t *agent, const addr_record_t *dst, const char *d
 	} else {
 		if (conn_impl->send_ds >= 0 && conn_impl->send_ds != ds) {
 			JLOG_VERBOSE("Setting Differentiated Services field to 0x%X", ds);
+#ifdef _WIN32
+			if (udp_set_diffserv_qwave(conn_impl->udp_sock, ds, agent) == 0)
+#else
 			if (udp_set_diffserv(conn_impl->udp_sock, ds) == 0)
+#endif
 				conn_impl->send_ds = ds;
 			else
 				conn_impl->send_ds = -1; // disable for next time

--- a/src/conn_thread.c
+++ b/src/conn_thread.c
@@ -250,7 +250,11 @@ int conn_thread_send(juice_agent_t *agent, const addr_record_t *dst, const char 
 
 	if (conn_impl->send_ds >= 0 && conn_impl->send_ds != ds) {
 		JLOG_VERBOSE("Setting Differentiated Services field to 0x%X", ds);
+#ifdef _WIN32
+		if (udp_set_diffserv_qwave(conn_impl->sock, ds, agent) == 0)
+#else
 		if (udp_set_diffserv(conn_impl->sock, ds) == 0)
+#endif
 			conn_impl->send_ds = ds;
 		else
 			conn_impl->send_ds = -1; // disable for next time

--- a/src/udp.h
+++ b/src/udp.h
@@ -27,9 +27,8 @@ int udp_sendto_self(socket_t sock, const char *data, size_t size);
 int udp_set_diffserv(socket_t sock, int ds);
 #ifdef _WIN32
 struct juice_agent;
-// Add to a standard traffic type, no admin permissions required
-int udp_set_qwave_traffic_type(socket_t sock, int traffic_type, struct juice_agent *agent);
-// Arbitrary DSCP values (requires admin permissions)
+int udp_set_traffic_type_qwave(socket_t sock, int traffic_type, struct juice_agent *agent,
+							 void *flow_id);
 int udp_set_diffserv_qwave(socket_t sock, int ds, struct juice_agent *agent);
 #endif
 uint16_t udp_get_port(socket_t sock);

--- a/src/udp.h
+++ b/src/udp.h
@@ -25,6 +25,13 @@ int udp_recvfrom(socket_t sock, char *buffer, size_t size, addr_record_t *src);
 int udp_sendto(socket_t sock, const char *data, size_t size, const addr_record_t *dst);
 int udp_sendto_self(socket_t sock, const char *data, size_t size);
 int udp_set_diffserv(socket_t sock, int ds);
+#ifdef _WIN32
+struct juice_agent;
+// Add to a standard traffic type, no admin permissions required
+int udp_set_qwave_traffic_type(socket_t sock, int traffic_type, struct juice_agent *agent);
+// Arbitrary DSCP values (requires admin permissions)
+int udp_set_diffserv_qwave(socket_t sock, int ds, struct juice_agent *agent);
+#endif
 uint16_t udp_get_port(socket_t sock);
 int udp_get_bound_addr(socket_t sock, addr_record_t *record);
 int udp_get_local_addr(socket_t sock, int family, addr_record_t *record); // family may be AF_UNSPEC


### PR DESCRIPTION
- Extend `juice_agent` to store QoS handle on windows
- Add QoS handle creation to `agent_create()`
- Add QoS handle cleanup to `agent_destroy()`
- Add Windows-specific QoS functions to udp.h/udp.c