### PR TITLE
build: remove 'f' modifier from ar invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ test/%.o: test/%.c
 -include $(subst .c,.d,$(SRCS))
 
 $(NAME).a: $(OBJS)
-	$(AR) crf $@ $(OBJS)
+	$(AR) cr $@ $(OBJS)
 
 $(NAME).so: $(OBJS)
 	$(CC) $(LDFLAGS) -shared -o $@ $(OBJS) $(LDLIBS)


### PR DESCRIPTION
The Makefile currently uses `crf` when invoking ar.
The `f` modifier is redundant when the archive name is explicitly provided
and is not supported by LLVM ar, which causes the build to fail on systems
where /usr/bin/ar points to llvm-ar (e.g. Chimera Linux).

Removing it preserves behavior with GNU ar.

Fixes #326.