### PR TITLE
fix: don't fail ICE when PAC timer expires with active nominated pair

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -1216,10 +1216,18 @@ int agent_bookkeeping(juice_agent_t *agent, timestamp_t *next_timestamp) {
 		// RFC 8863: While the timer is still running, the ICE agent MUST NOT update a checklist
 		// state from Running to Failed, even if there are no pairs left in the checklist to check.
 		if (now >= agent->pac_timestamp) {
-			JLOG_INFO("Connectivity timer expired");
-			agent_change_state(agent, JUICE_STATE_FAILED);
-			atomic_store(&agent->selected_entry, NULL); // disallow sending
-			return 0;
+			// Don't fail if we have an active nominated pair with valid consent.
+			// The PAC timer is meant to catch the case where no pair is ever nominated,
+			// not to kill a working connection.
+			agent_stun_entry_t *selected = atomic_load(&agent->selected_entry);
+			if (selected && selected->state == AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE) {
+				agent->pac_timestamp = 0; // clear timer, connection is healthy
+			} else {
+				JLOG_INFO("Connectivity timer expired");
+				agent_change_state(agent, JUICE_STATE_FAILED);
+				atomic_store(&agent->selected_entry, NULL); // disallow sending
+				return 0;
+			}
 		} else if (*next_timestamp > agent->pac_timestamp) {
 			*next_timestamp = agent->pac_timestamp;
 		}


### PR DESCRIPTION
When the STUN server binding fails after gathering completes, the PAC timer fires and unconditionally transitions ICE to the Failed state — even when a nominated candidate pair is active with successful keepalives. This kills working P2P connections on networks where the STUN server is unreachable but direct connectivity works fine.

Check for an active selected entry in SUCCEEDED_KEEPALIVE state before failing. If the connection is healthy, clear the timer instead.