### PR TITLE
fix: don't kill connection when recv fairness limit is reached

### DIFF
--- a/src/conn_poll.c
+++ b/src/conn_poll.c
@@ -264,6 +264,10 @@ void conn_poll_process_udp(juice_agent_t *agent, struct pollfd *pfd) {
 
 		if (ret == -SEAGAIN || ret == -SEWOULDBLOCK) {
 			JLOG_VERBOSE("No more datagrams to receive");
+		} else if (ret > 0) {
+			// Fairness limit reached — there are more datagrams but we need to
+			// give other sockets a turn. This is not an error.
+			JLOG_VERBOSE("Fairness limit reached, will continue on next poll");
 		} else {
 			agent_conn_fail(agent);
 			conn_impl->state = CONN_STATE_FINISHED;


### PR DESCRIPTION
When more than 1000 UDP datagrams queue up in a single poll cycle (common on localhost with high-throughput WebRTC), the fairness limiter exits the recv loop with ret > 0. The subsequent check only handles EAGAIN/EWOULDBLOCK, so ret > 0 falls into the else branch and calls agent_conn_fail(), killing a perfectly healthy connection.

Treat ret > 0 after the loop as a normal fairness exit, not an error.