### PR TITLE
Fixes and enhancements to ICE-TCP

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -74,6 +74,10 @@ static int copy_turn_server(juice_turn_server_t *dst, const juice_turn_server_t 
 	return 0;
 }
 
+static bool entry_is_tcp(agent_stun_entry_t *entry) {
+	return (entry->pair && entry->pair->remote->transport != ICE_CANDIDATE_TRANSPORT_UDP);
+}
+
 juice_agent_t *agent_create(const juice_config_t *config) {
 	JLOG_VERBOSE("Creating agent");
 
@@ -875,18 +879,20 @@ void agent_register_entry_for_candidate_pair(juice_agent_t *agent, ice_candidate
 int agent_conn_tcp_state(juice_agent_t *agent, const addr_record_t *dst, tcp_state_t state) {
 	for (int i = 0; i < agent->entries_count; ++i) {
 		agent_stun_entry_t *entry = agent->entries + i;
-		if (entry->pair && entry->pair->remote->transport != ICE_CANDIDATE_TRANSPORT_UDP &&
-		    addr_record_is_equal(&entry->record, dst, true)) {
-			entry->pair->tcp_state = state;
+		if (entry_is_tcp(entry) && addr_record_is_equal(&entry->record, dst, true)) {
+			entry->tcp_state = state;
 			switch (state) {
 			case TCP_STATE_CONNECTED:
 				agent_arm_transmission(agent, entry, 0); // transmit now
 				break;
 			case TCP_STATE_DISCONNECTED:
 			case TCP_STATE_FAILED:
-				entry->pair->state = ICE_CANDIDATE_PAIR_STATE_FAILED;
 				entry->state = AGENT_STUN_ENTRY_STATE_FAILED;
 				entry->next_transmission = 0;
+
+				if(entry->pair)
+					entry->pair->state = ICE_CANDIDATE_PAIR_STATE_FAILED;
+
 				conn_interrupt(agent);
 				break;
 			default:
@@ -916,11 +922,11 @@ int agent_bookkeeping(juice_agent_t *agent, timestamp_t *next_timestamp) {
 			if (entry->next_transmission > now)
 				continue;
 
-			if (entry->pair && entry->pair->remote->transport != ICE_CANDIDATE_TRANSPORT_UDP) {
-			    if (entry->pair->tcp_state == TCP_STATE_DISCONNECTED)
+			if (entry_is_tcp(entry)) {
+			    if (entry->tcp_state == TCP_STATE_DISCONNECTED)
 					conn_tcp_connect(agent, &entry->record); // First attempt a TCP connection
 
-				if(entry->pair->tcp_state != TCP_STATE_CONNECTED)
+				if(entry->tcp_state != TCP_STATE_CONNECTED)
 					continue;
 			}
 
@@ -2556,7 +2562,7 @@ void agent_arm_transmission(juice_agent_t *agent, agent_stun_entry_t *entry, tim
 	entry->next_transmission = current_timestamp() + delay;
 
 	if (entry->state == AGENT_STUN_ENTRY_STATE_PENDING) {
-		if (entry->pair && entry->pair->remote->transport != ICE_CANDIDATE_TRANSPORT_UDP) {
+		if (entry_is_tcp(entry)) {
 			entry->retransmission_timeout = STUN_TCP_TIMEOUT;
 			entry->retransmissions = 0; // do not retransmit
 		} else {

--- a/src/agent.h
+++ b/src/agent.h
@@ -116,6 +116,7 @@ typedef struct agent_stun_entry {
 	timediff_t retransmission_timeout;
 	int retransmissions;
 	bool transaction_id_expired;
+	tcp_state_t tcp_state;
 
 	// TURN
 	agent_turn_state_t *turn;

--- a/src/conn_poll.c
+++ b/src/conn_poll.c
@@ -40,7 +40,6 @@ typedef struct conn_impl {
 	tcp_ice_read_context_t tcp_ice_read_context;
 	addr_record_t tcp_dst;
 	tcp_state_t tcp_state;
-	uint16_t ice_tcp_len;
 	mutex_t send_mutex;
 	int send_ds;
 	timestamp_t next_timestamp;

--- a/src/conn_poll.c
+++ b/src/conn_poll.c
@@ -359,7 +359,7 @@ void conn_poll_process_tcp(juice_agent_t *agent, struct pollfd *pfd) {
 		int left = 1000; // limit for fairness between sockets
 		while (left--) {
 			tcp_ice_read_context_t *context = &conn_impl->tcp_ice_read_context;
-			if ((ret = tcp_ice_read(conn_impl->tcp_sock, context)) < 0) {
+			if ((ret = tcp_ice_read(conn_impl->tcp_sock, context)) <= 0) {
 				break;
 			}
 

--- a/src/conn_poll.c
+++ b/src/conn_poll.c
@@ -261,12 +261,11 @@ void conn_poll_process_udp(juice_agent_t *agent, struct pollfd *pfd) {
 		if (conn_impl->state == CONN_STATE_FINISHED)
 			return;
 
-		if (ret == -SEAGAIN || ret == -SEWOULDBLOCK) {
-			JLOG_VERBOSE("No more datagrams to receive");
-		} else if (ret > 0) {
-			// Fairness limit reached — there are more datagrams but we need to
-			// give other sockets a turn. This is not an error.
+		if (ret > 0) {
+			// There are more datagrams but we need to give other sockets a turn
 			JLOG_VERBOSE("Fairness limit reached, will continue on next poll");
+		} else if (ret == -SEAGAIN || ret == -SEWOULDBLOCK) {
+			JLOG_VERBOSE("No more datagrams to receive");
 		} else {
 			agent_conn_fail(agent);
 			conn_impl->state = CONN_STATE_FINISHED;
@@ -372,9 +371,12 @@ void conn_poll_process_tcp(juice_agent_t *agent, struct pollfd *pfd) {
 		if (conn_impl->state == CONN_STATE_FINISHED)
 			return;
 
-		if (ret == -SEAGAIN || ret == -SEWOULDBLOCK) {
+		if (ret > 0) {
+			// There are more datagrams but we need to give other sockets a turn
+			JLOG_VERBOSE("Fairness limit reached, will continue on next poll");
+		} else if (ret == -SEAGAIN || ret == -SEWOULDBLOCK) {
 			JLOG_VERBOSE("No more ICE-TCP datagrams to receive");
-		} else if (ret <= 0) {
+		} else {
 			if (ret == 0) JLOG_DEBUG("TCP connection closed");
 			else JLOG_DEBUG("TCP connection failed");
 			conn_poll_change_tcp_fail(agent);

--- a/src/ice.h
+++ b/src/ice.h
@@ -79,7 +79,6 @@ typedef struct ice_candidate_pair {
 	ice_candidate_pair_state_t state;
 	bool nominated;
 	bool nomination_requested;
-	tcp_state_t tcp_state;
 	timestamp_t consent_expiry;
 } ice_candidate_pair_t;
 

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -127,7 +127,7 @@ int tcp_ice_read(socket_t sock, tcp_ice_read_context_t *context) {
 		}
 
 		if (len == 0)
-			return len; // closed
+			return 0; // closed
 
 		context->bytes_read += len;
 

--- a/test/tcp.c
+++ b/test/tcp.c
@@ -79,11 +79,8 @@ void run_passive_ice_tcp(socket_t server_socket) {
 
 	for (int i = 0; i < 2;) {
 		int len;
-		if ((len = _juice_tcp_ice_read(client_socket, &read_context)) < 0)
+		if ((len = _juice_tcp_ice_read(client_socket, &read_context)) <= 0)
 			return;
-
-		if (len == 0)
-			continue;
 
 		stun_message_t msg;
 		memset(&msg, 0, sizeof(msg));


### PR DESCRIPTION
- Fix TCP close handling on TCP ICE read
- Move TCP state to entry and introduce `entry_is_tcp()` (in the future an entry could also be TURN-TCP)
- Cleanup leftover `ice_tcp_len.`
- Align `conn_poll_process_udp()` and `conn_poll_process_tcp()` fairness check