### PR TITLE
Rename functions to resolve naming collisions

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -16,7 +16,7 @@
 #include "picohash.h"
 #endif
 
-void hash_md5(const void *message, size_t size, void *digest) {
+void juice_hash_md5(const void *message, size_t size, void *digest) {
 #if USE_NETTLE
 	struct md5_ctx ctx;
 	md5_init(&ctx);
@@ -30,7 +30,7 @@ void hash_md5(const void *message, size_t size, void *digest) {
 #endif
 }
 
-void hash_sha1(const void *message, size_t size, void *digest) {
+void juice_hash_sha1(const void *message, size_t size, void *digest) {
 #if USE_NETTLE
 	struct sha1_ctx ctx;
 	sha1_init(&ctx);
@@ -44,7 +44,7 @@ void hash_sha1(const void *message, size_t size, void *digest) {
 #endif
 }
 
-void hash_sha256(const void *message, size_t size, void *digest) {
+void juice_hash_sha256(const void *message, size_t size, void *digest) {
 #if USE_NETTLE
 	struct sha256_ctx ctx;
 	sha256_init(&ctx);

--- a/src/hash.h
+++ b/src/hash.h
@@ -16,8 +16,8 @@
 #define HASH_SHA1_SIZE 24
 #define HASH_SHA256_SIZE 32
 
-void hash_md5(const void *message, size_t size, void *digest);
-void hash_sha1(const void *message, size_t size, void *digest);
-void hash_sha256(const void *message, size_t size, void *digest);
+void juice_hash_md5(const void *message, size_t size, void *digest);
+void juice_hash_sha1(const void *message, size_t size, void *digest);
+void juice_hash_sha256(const void *message, size_t size, void *digest);
 
 #endif

--- a/src/stun.c
+++ b/src/stun.c
@@ -70,10 +70,10 @@ static size_t generate_hmac_key(const stun_message_t *msg, const char *password,
 
 		switch (msg->credentials.password_algorithm) {
 		case STUN_PASSWORD_ALGORITHM_SHA256:
-			hash_sha256(input, input_len, key);
+			juice_hash_sha256(input, input_len, key);
 			return HASH_SHA256_SIZE;
 		default:
-			hash_md5(input, input_len, key);
+			juice_hash_md5(input, input_len, key);
 			return HASH_MD5_SIZE;
 		}
 	} else {
@@ -1188,7 +1188,7 @@ void stun_compute_userhash(const char *username, const char *realm, uint8_t *out
 	if (input_len >= MAX_USERHASH_INPUT_LEN)
 		input_len = MAX_USERHASH_INPUT_LEN - 1;
 
-	hash_sha256(input, input_len, out);
+	juice_hash_sha256(input, input_len, out);
 }
 
 void stun_process_credentials(const stun_credentials_t *credentials, stun_credentials_t *dst) {


### PR DESCRIPTION
This pull request renames the internal hashing function identifiers throughout the codebase to use a `juice_` prefix, improving clarity and avoiding potential naming conflicts. All usages and declarations of the MD5, SHA1, and SHA256 hash functions have been updated accordingly.

**Hash function renaming:**

* Renamed `hash_md5`, `hash_sha1`, and `hash_sha256` to `juice_hash_md5`, `juice_hash_sha1`, and `juice_hash_sha256` in both their function implementations in `src/hash.c` and declarations in `src/hash.h`. [[1]](diffhunk://#diff-f5cfaadff11f4b360f585fa310cea434867582e77e6e436cc9bbb9392352662bL19-R19) [[2]](diffhunk://#diff-f5cfaadff11f4b360f585fa310cea434867582e77e6e436cc9bbb9392352662bL33-R33) [[3]](diffhunk://#diff-f5cfaadff11f4b360f585fa310cea434867582e77e6e436cc9bbb9392352662bL47-R47) [[4]](diffhunk://#diff-d3f64e14005fbfea3d4f72b076764ac897d0df451de0ab2fb1c57a5f87cd793bL19-R21)

**Call site updates:**

* Updated all usages of the old hash function names to the new `juice_`-prefixed versions in `src/stun.c`, specifically in the `generate_hmac_key` and `stun_compute_userhash` functions. [[1]](diffhunk://#diff-9c28190fa91c6b03bdc60750d70f37b4df4349333effa42219a95b7df9040fd9L73-R76) [[2]](diffhunk://#diff-9c28190fa91c6b03bdc60750d70f37b4df4349333effa42219a95b7df9040fd9L1191-R1191)