### PR TITLE
Allow to close turn allocations

### DIFF
--- a/include/juice/juice.h
+++ b/include/juice/juice.h
@@ -121,6 +121,7 @@ typedef struct juice_config {
 JUICE_EXPORT juice_agent_t *juice_create(const juice_config_t *config);
 JUICE_EXPORT void juice_destroy(juice_agent_t *agent);
 
+JUICE_EXPORT int juice_close_turn_allocation(juice_agent_t *agent);
 JUICE_EXPORT int juice_gather_candidates(juice_agent_t *agent);
 JUICE_EXPORT int juice_get_local_description(juice_agent_t *agent, char *buffer, size_t size);
 JUICE_EXPORT int juice_set_remote_description(juice_agent_t *agent, const char *sdp);

--- a/src/agent.c
+++ b/src/agent.c
@@ -74,10 +74,6 @@ static int copy_turn_server(juice_turn_server_t *dst, const juice_turn_server_t 
 	return 0;
 }
 
-static bool entry_is_tcp(agent_stun_entry_t *entry) {
-	return (entry->pair && entry->pair->remote->transport != ICE_CANDIDATE_TRANSPORT_UDP);
-}
-
 juice_agent_t *agent_create(const juice_config_t *config) {
 	JLOG_VERBOSE("Creating agent");
 
@@ -879,20 +875,18 @@ void agent_register_entry_for_candidate_pair(juice_agent_t *agent, ice_candidate
 int agent_conn_tcp_state(juice_agent_t *agent, const addr_record_t *dst, tcp_state_t state) {
 	for (int i = 0; i < agent->entries_count; ++i) {
 		agent_stun_entry_t *entry = agent->entries + i;
-		if (entry_is_tcp(entry) && addr_record_is_equal(&entry->record, dst, true)) {
-			entry->tcp_state = state;
+		if (entry->pair && entry->pair->remote->transport != ICE_CANDIDATE_TRANSPORT_UDP &&
+		    addr_record_is_equal(&entry->record, dst, true)) {
+			entry->pair->tcp_state = state;
 			switch (state) {
 			case TCP_STATE_CONNECTED:
 				agent_arm_transmission(agent, entry, 0); // transmit now
 				break;
 			case TCP_STATE_DISCONNECTED:
 			case TCP_STATE_FAILED:
+				entry->pair->state = ICE_CANDIDATE_PAIR_STATE_FAILED;
 				entry->state = AGENT_STUN_ENTRY_STATE_FAILED;
 				entry->next_transmission = 0;
-
-				if(entry->pair)
-					entry->pair->state = ICE_CANDIDATE_PAIR_STATE_FAILED;
-
 				conn_interrupt(agent);
 				break;
 			default:
@@ -922,11 +916,11 @@ int agent_bookkeeping(juice_agent_t *agent, timestamp_t *next_timestamp) {
 			if (entry->next_transmission > now)
 				continue;
 
-			if (entry_is_tcp(entry)) {
-			    if (entry->tcp_state == TCP_STATE_DISCONNECTED)
+			if (entry->pair && entry->pair->remote->transport != ICE_CANDIDATE_TRANSPORT_UDP) {
+			    if (entry->pair->tcp_state == TCP_STATE_DISCONNECTED)
 					conn_tcp_connect(agent, &entry->record); // First attempt a TCP connection
 
-				if(entry->tcp_state != TCP_STATE_CONNECTED)
+				if(entry->pair->tcp_state != TCP_STATE_CONNECTED)
 					continue;
 			}
 
@@ -998,7 +992,7 @@ int agent_bookkeeping(juice_agent_t *agent, timestamp_t *next_timestamp) {
 		}
 		// STUN keepalives
 		else if (entry->state == AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE) {
-#if defined(JUICE_DISABLE_CONSENT_FRESHNESS) && JUICE_DISABLE_CONSENT_FRESHNESS
+#if JUICE_DISABLE_CONSENT_FRESHNESS
 			// No expiration
 #else
 			// Consent freshness expiration
@@ -1034,7 +1028,7 @@ int agent_bookkeeping(juice_agent_t *agent, timestamp_t *next_timestamp) {
 				ret = agent_send_stun_binding(agent, entry, STUN_CLASS_REQUEST, 0, NULL, NULL);
 				break;
 			default:
-#if defined(JUICE_DISABLE_CONSENT_FRESHNESS) && JUICE_DISABLE_CONSENT_FRESHNESS
+#if JUICE_DISABLE_CONSENT_FRESHNESS
 				// RFC 8445 11. Keepalives:
 				// All endpoints MUST send keepalives for each data session. [...] STUN keepalives
 				// MUST be used when an ICE agent is a full ICE implementation and is communicating
@@ -1046,7 +1040,7 @@ int agent_bookkeeping(juice_agent_t *agent, timestamp_t *next_timestamp) {
 				// STUN binding requests sent for consent freshness also serve the keepalive purpose
 				// (i.e., to keep NAT bindings alive). Because of that, dedicated keepalives (e.g.,
 				// STUN Binding Indications) are not sent on candidate pairs where consent requests
-				// are sent, in accordance with Section 20.2.3 of [RFC5245].
+				// are sent, in accordance with Section 20.2.3 of [RFC5245].
 				ret = agent_send_stun_binding(agent, entry, STUN_CLASS_REQUEST, 0, NULL, NULL);
 #endif
 				break;
@@ -1236,7 +1230,7 @@ int agent_bookkeeping(juice_agent_t *agent, timestamp_t *next_timestamp) {
 		if (entry->next_transmission && *next_timestamp > entry->next_transmission)
 			*next_timestamp = entry->next_transmission;
 
-#if defined(JUICE_DISABLE_CONSENT_FRESHNESS) && JUICE_DISABLE_CONSENT_FRESHNESS
+#if JUICE_DISABLE_CONSENT_FRESHNESS
 		// No expiration
 #else
 		if (entry->state == AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE && entry->pair &&
@@ -1961,8 +1955,8 @@ int agent_process_turn_allocate(juice_agent_t *agent, const stun_message_t *msg,
 	return 0;
 }
 
-int agent_send_turn_allocate_request(juice_agent_t *agent, const agent_stun_entry_t *entry,
-                                     stun_method_t method) {
+int agent_send_turn_allocate_request_lifetime(juice_agent_t *agent, const agent_stun_entry_t *entry,
+                                              stun_method_t method, uint32_t lifetime) {
 	if (method != STUN_METHOD_ALLOCATE && method != STUN_METHOD_REFRESH)
 		return -1;
 
@@ -1984,7 +1978,8 @@ int agent_send_turn_allocate_request(juice_agent_t *agent, const agent_stun_entr
 	msg.msg_method = method;
 	memcpy(msg.transaction_id, entry->transaction_id, STUN_TRANSACTION_ID_SIZE);
 
-	msg.lifetime = TURN_LIFETIME / 1000; // seconds
+	msg.lifetime = lifetime / 1000; // seconds
+	msg.lifetime_set = true;
 
 	// Include allocation attributes in Allocate request only
 	if (method == STUN_METHOD_ALLOCATE) {
@@ -2008,6 +2003,11 @@ int agent_send_turn_allocate_request(juice_agent_t *agent, const agent_stun_entr
 		return -1;
 	}
 	return 0;
+}
+
+int agent_send_turn_allocate_request(juice_agent_t *agent, const agent_stun_entry_t *entry,
+                                     stun_method_t method) {
+	return agent_send_turn_allocate_request_lifetime(agent, entry, method, TURN_LIFETIME);
 }
 
 int agent_process_turn_create_permission(juice_agent_t *agent, const stun_message_t *msg,
@@ -2541,7 +2541,7 @@ void agent_arm_keepalive(juice_agent_t *agent, agent_stun_entry_t *entry) {
 		period = STUN_KEEPALIVE_PERIOD;
 		break;
 	default:
-#if defined(JUICE_DISABLE_CONSENT_FRESHNESS) && JUICE_DISABLE_CONSENT_FRESHNESS
+#if JUICE_DISABLE_CONSENT_FRESHNESS
 		period = STUN_KEEPALIVE_PERIOD;
 #else
 		period = MIN_CONSENT_CHECK_PERIOD +
@@ -2562,7 +2562,7 @@ void agent_arm_transmission(juice_agent_t *agent, agent_stun_entry_t *entry, tim
 	entry->next_transmission = current_timestamp() + delay;
 
 	if (entry->state == AGENT_STUN_ENTRY_STATE_PENDING) {
-		if (entry_is_tcp(entry)) {
+		if (entry->pair && entry->pair->remote->transport != ICE_CANDIDATE_TRANSPORT_UDP) {
 			entry->retransmission_timeout = STUN_TCP_TIMEOUT;
 			entry->retransmissions = 0; // do not retransmit
 		} else {
@@ -2764,7 +2764,7 @@ void agent_translate_host_candidate_entry(juice_agent_t *agent, agent_stun_entry
 	if (!entry->pair || entry->pair->remote->type != ICE_CANDIDATE_TYPE_HOST)
 		return;
 
-#if defined(JUICE_ENABLE_LOCAL_ADDRESS_TRANSLATION) && JUICE_ENABLE_LOCAL_ADDRESS_TRANSLATION
+#if JUICE_ENABLE_LOCAL_ADDRESS_TRANSLATION
 	for (int i = 0; i < agent->local.candidates_count; ++i) {
 		ice_candidate_t *candidate = agent->local.candidates + i;
 		if (candidate->type != ICE_CANDIDATE_TYPE_HOST)

--- a/src/agent.c
+++ b/src/agent.c
@@ -74,6 +74,10 @@ static int copy_turn_server(juice_turn_server_t *dst, const juice_turn_server_t 
 	return 0;
 }
 
+static bool entry_is_tcp(agent_stun_entry_t *entry) {
+	return (entry->pair && entry->pair->remote->transport != ICE_CANDIDATE_TRANSPORT_UDP);
+}
+
 juice_agent_t *agent_create(const juice_config_t *config) {
 	JLOG_VERBOSE("Creating agent");
 
@@ -875,18 +879,20 @@ void agent_register_entry_for_candidate_pair(juice_agent_t *agent, ice_candidate
 int agent_conn_tcp_state(juice_agent_t *agent, const addr_record_t *dst, tcp_state_t state) {
 	for (int i = 0; i < agent->entries_count; ++i) {
 		agent_stun_entry_t *entry = agent->entries + i;
-		if (entry->pair && entry->pair->remote->transport != ICE_CANDIDATE_TRANSPORT_UDP &&
-		    addr_record_is_equal(&entry->record, dst, true)) {
-			entry->pair->tcp_state = state;
+		if (entry_is_tcp(entry) && addr_record_is_equal(&entry->record, dst, true)) {
+			entry->tcp_state = state;
 			switch (state) {
 			case TCP_STATE_CONNECTED:
 				agent_arm_transmission(agent, entry, 0); // transmit now
 				break;
 			case TCP_STATE_DISCONNECTED:
 			case TCP_STATE_FAILED:
-				entry->pair->state = ICE_CANDIDATE_PAIR_STATE_FAILED;
 				entry->state = AGENT_STUN_ENTRY_STATE_FAILED;
 				entry->next_transmission = 0;
+
+				if(entry->pair)
+					entry->pair->state = ICE_CANDIDATE_PAIR_STATE_FAILED;
+
 				conn_interrupt(agent);
 				break;
 			default:
@@ -916,11 +922,11 @@ int agent_bookkeeping(juice_agent_t *agent, timestamp_t *next_timestamp) {
 			if (entry->next_transmission > now)
 				continue;
 
-			if (entry->pair && entry->pair->remote->transport != ICE_CANDIDATE_TRANSPORT_UDP) {
-			    if (entry->pair->tcp_state == TCP_STATE_DISCONNECTED)
+			if (entry_is_tcp(entry)) {
+			    if (entry->tcp_state == TCP_STATE_DISCONNECTED)
 					conn_tcp_connect(agent, &entry->record); // First attempt a TCP connection
 
-				if(entry->pair->tcp_state != TCP_STATE_CONNECTED)
+				if(entry->tcp_state != TCP_STATE_CONNECTED)
 					continue;
 			}
 
@@ -992,7 +998,7 @@ int agent_bookkeeping(juice_agent_t *agent, timestamp_t *next_timestamp) {
 		}
 		// STUN keepalives
 		else if (entry->state == AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE) {
-#if JUICE_DISABLE_CONSENT_FRESHNESS
+#if defined(JUICE_DISABLE_CONSENT_FRESHNESS) && JUICE_DISABLE_CONSENT_FRESHNESS
 			// No expiration
 #else
 			// Consent freshness expiration
@@ -1028,7 +1034,7 @@ int agent_bookkeeping(juice_agent_t *agent, timestamp_t *next_timestamp) {
 				ret = agent_send_stun_binding(agent, entry, STUN_CLASS_REQUEST, 0, NULL, NULL);
 				break;
 			default:
-#if JUICE_DISABLE_CONSENT_FRESHNESS
+#if defined(JUICE_DISABLE_CONSENT_FRESHNESS) && JUICE_DISABLE_CONSENT_FRESHNESS
 				// RFC 8445 11. Keepalives:
 				// All endpoints MUST send keepalives for each data session. [...] STUN keepalives
 				// MUST be used when an ICE agent is a full ICE implementation and is communicating
@@ -1040,7 +1046,7 @@ int agent_bookkeeping(juice_agent_t *agent, timestamp_t *next_timestamp) {
 				// STUN binding requests sent for consent freshness also serve the keepalive purpose
 				// (i.e., to keep NAT bindings alive). Because of that, dedicated keepalives (e.g.,
 				// STUN Binding Indications) are not sent on candidate pairs where consent requests
-				// are sent, in accordance with Section 20.2.3 of [RFC5245].
+				// are sent, in accordance with Section 20.2.3 of [RFC5245].
 				ret = agent_send_stun_binding(agent, entry, STUN_CLASS_REQUEST, 0, NULL, NULL);
 #endif
 				break;
@@ -1230,7 +1236,7 @@ int agent_bookkeeping(juice_agent_t *agent, timestamp_t *next_timestamp) {
 		if (entry->next_transmission && *next_timestamp > entry->next_transmission)
 			*next_timestamp = entry->next_transmission;
 
-#if JUICE_DISABLE_CONSENT_FRESHNESS
+#if defined(JUICE_DISABLE_CONSENT_FRESHNESS) && JUICE_DISABLE_CONSENT_FRESHNESS
 		// No expiration
 #else
 		if (entry->state == AGENT_STUN_ENTRY_STATE_SUCCEEDED_KEEPALIVE && entry->pair &&
@@ -1956,7 +1962,7 @@ int agent_process_turn_allocate(juice_agent_t *agent, const stun_message_t *msg,
 }
 
 int agent_send_turn_allocate_request_lifetime(juice_agent_t *agent, const agent_stun_entry_t *entry,
-                                              stun_method_t method, uint32_t lifetime) {
+                                              stun_method_t method) {
 	if (method != STUN_METHOD_ALLOCATE && method != STUN_METHOD_REFRESH)
 		return -1;
 
@@ -1980,7 +1986,7 @@ int agent_send_turn_allocate_request_lifetime(juice_agent_t *agent, const agent_
 
 	msg.lifetime = lifetime / 1000; // seconds
 	msg.lifetime_set = true;
-
+	
 	// Include allocation attributes in Allocate request only
 	if (method == STUN_METHOD_ALLOCATE) {
 		msg.requested_transport = true;
@@ -2541,7 +2547,7 @@ void agent_arm_keepalive(juice_agent_t *agent, agent_stun_entry_t *entry) {
 		period = STUN_KEEPALIVE_PERIOD;
 		break;
 	default:
-#if JUICE_DISABLE_CONSENT_FRESHNESS
+#if defined(JUICE_DISABLE_CONSENT_FRESHNESS) && JUICE_DISABLE_CONSENT_FRESHNESS
 		period = STUN_KEEPALIVE_PERIOD;
 #else
 		period = MIN_CONSENT_CHECK_PERIOD +
@@ -2562,7 +2568,7 @@ void agent_arm_transmission(juice_agent_t *agent, agent_stun_entry_t *entry, tim
 	entry->next_transmission = current_timestamp() + delay;
 
 	if (entry->state == AGENT_STUN_ENTRY_STATE_PENDING) {
-		if (entry->pair && entry->pair->remote->transport != ICE_CANDIDATE_TRANSPORT_UDP) {
+		if (entry_is_tcp(entry)) {
 			entry->retransmission_timeout = STUN_TCP_TIMEOUT;
 			entry->retransmissions = 0; // do not retransmit
 		} else {
@@ -2764,7 +2770,7 @@ void agent_translate_host_candidate_entry(juice_agent_t *agent, agent_stun_entry
 	if (!entry->pair || entry->pair->remote->type != ICE_CANDIDATE_TYPE_HOST)
 		return;
 
-#if JUICE_ENABLE_LOCAL_ADDRESS_TRANSLATION
+#if defined(JUICE_ENABLE_LOCAL_ADDRESS_TRANSLATION) && JUICE_ENABLE_LOCAL_ADDRESS_TRANSLATION
 	for (int i = 0; i < agent->local.candidates_count; ++i) {
 		ice_candidate_t *candidate = agent->local.candidates + i;
 		if (candidate->type != ICE_CANDIDATE_TYPE_HOST)

--- a/src/agent.c
+++ b/src/agent.c
@@ -1962,7 +1962,7 @@ int agent_process_turn_allocate(juice_agent_t *agent, const stun_message_t *msg,
 }
 
 int agent_send_turn_allocate_request_lifetime(juice_agent_t *agent, const agent_stun_entry_t *entry,
-                                              stun_method_t method) {
+                                              stun_method_t method, uint32_t lifetime) {
 	if (method != STUN_METHOD_ALLOCATE && method != STUN_METHOD_REFRESH)
 		return -1;
 

--- a/src/agent.h
+++ b/src/agent.h
@@ -204,6 +204,8 @@ int agent_process_turn_allocate(juice_agent_t *agent, const stun_message_t *msg,
                                 agent_stun_entry_t *entry);
 int agent_send_turn_allocate_request(juice_agent_t *agent, const agent_stun_entry_t *entry,
                                      stun_method_t method);
+int agent_send_turn_allocate_request_lifetime(juice_agent_t *agent, const agent_stun_entry_t *entry,
+                                     stun_method_t method, uint32_t lifetime);
 int agent_process_turn_create_permission(juice_agent_t *agent, const stun_message_t *msg,
                                          agent_stun_entry_t *entry);
 int agent_send_turn_create_permission_request(juice_agent_t *agent, agent_stun_entry_t *entry,

--- a/src/agent.h
+++ b/src/agent.h
@@ -205,7 +205,7 @@ int agent_process_turn_allocate(juice_agent_t *agent, const stun_message_t *msg,
 int agent_send_turn_allocate_request(juice_agent_t *agent, const agent_stun_entry_t *entry,
                                      stun_method_t method);
 int agent_send_turn_allocate_request_lifetime(juice_agent_t *agent, const agent_stun_entry_t *entry,
-                                     stun_method_t method, uint32_t lifetime);
+                                              stun_method_t method, uint32_t lifetime);
 int agent_process_turn_create_permission(juice_agent_t *agent, const stun_message_t *msg,
                                          agent_stun_entry_t *entry);
 int agent_send_turn_create_permission_request(juice_agent_t *agent, agent_stun_entry_t *entry,

--- a/src/juice.c
+++ b/src/juice.c
@@ -82,7 +82,6 @@ JUICE_EXPORT int juice_close_turn_allocation(juice_agent_t *agent) {
 
 	return JUICE_ERR_SUCCESS;
 }
-}
 
 JUICE_EXPORT int juice_gather_candidates(juice_agent_t *agent) {
 	if (!agent)

--- a/src/juice.c
+++ b/src/juice.c
@@ -37,7 +37,7 @@ JUICE_EXPORT int juice_close_turn_allocation(juice_agent_t *agent) {
 	JLOG_DEBUG("Sending TURN Refresh(0) for all relay entries");
 
 	conn_lock(agent);
-	
+
 	for (int i = 0; i < agent->entries_count; ++i) {
 		agent_stun_entry_t *entry = &agent->entries[i];
 
@@ -52,18 +52,26 @@ JUICE_EXPORT int juice_close_turn_allocation(juice_agent_t *agent) {
 			continue;
 		}
 
+		if (!entry->transaction_id_expired) {
+			JLOG_WARN("Entry %d has a pending STUN transaction, overwriting", i);
+		}
+
 		JLOG_INFO("Sending Refresh(0) for entry %d", i);
+
+		juice_random(entry->transaction_id, STUN_TRANSACTION_ID_SIZE);
+		entry->transaction_id_expired = false;
 
 		int ret = agent_send_turn_allocate_request_lifetime(
 						agent,
 						entry,
 						STUN_METHOD_REFRESH,
-						0  // lifetime of 0 to close the allocation
+						0  // lifetime of 0 to request to close the allocation
 		);
 
 		if (ret < 0) {
 			JLOG_WARN("Failed to send TURN Refresh(0) for entry %d with error code %d", i, ret);
-		}else{
+			entry->transaction_id_expired = true;
+		} else {
 			JLOG_VERBOSE("Successfully sent TURN Refresh(0) for entry %d", i);
 		}
 	}
@@ -73,6 +81,7 @@ JUICE_EXPORT int juice_close_turn_allocation(juice_agent_t *agent) {
 	JLOG_DEBUG("Finished sending TURN Refresh(0) for all relay entries");
 
 	return JUICE_ERR_SUCCESS;
+}
 }
 
 JUICE_EXPORT int juice_gather_candidates(juice_agent_t *agent) {

--- a/src/juice.c
+++ b/src/juice.c
@@ -36,6 +36,8 @@ JUICE_EXPORT int juice_close_turn_allocation(juice_agent_t *agent) {
 
 	JLOG_DEBUG("Sending TURN Refresh(0) for all relay entries");
 
+	conn_lock(agent);
+	
 	for (int i = 0; i < agent->entries_count; ++i) {
 		agent_stun_entry_t *entry = &agent->entries[i];
 
@@ -65,6 +67,8 @@ JUICE_EXPORT int juice_close_turn_allocation(juice_agent_t *agent) {
 			JLOG_VERBOSE("Successfully sent TURN Refresh(0) for entry %d", i);
 		}
 	}
+
+	conn_unlock(agent);
 
 	JLOG_DEBUG("Finished sending TURN Refresh(0) for all relay entries");
 

--- a/src/juice.c
+++ b/src/juice.c
@@ -30,6 +30,47 @@ JUICE_EXPORT void juice_destroy(juice_agent_t *agent) {
 		agent_destroy(agent);
 }
 
+JUICE_EXPORT int juice_close_turn_allocation(juice_agent_t *agent) {
+	if (!agent)
+		return JUICE_ERR_INVALID;
+
+	JLOG_DEBUG("Sending TURN Refresh(0) for all relay entries");
+
+	for (int i = 0; i < agent->entries_count; ++i) {
+		agent_stun_entry_t *entry = &agent->entries[i];
+
+		// Only refresh relay entries with an active TURN allocation
+		if (entry->type != AGENT_STUN_ENTRY_TYPE_RELAY){
+			JLOG_VERBOSE("Skipping entry %d: not a relay entry", i);
+			continue;
+		}
+
+		if (!entry->turn){
+			JLOG_VERBOSE("Skipping entry %d: no active TURN allocation", i);
+			continue;
+		}
+
+		JLOG_INFO("Sending Refresh(0) for entry %d", i);
+
+		int ret = agent_send_turn_allocate_request_lifetime(
+						agent,
+						entry,
+						STUN_METHOD_REFRESH,
+						0  // lifetime of 0 to close the allocation
+		);
+
+		if (ret < 0) {
+			JLOG_WARN("Failed to send TURN Refresh(0) for entry %d with error code %d", i, ret);
+		}else{
+			JLOG_VERBOSE("Successfully sent TURN Refresh(0) for entry %d", i);
+		}
+	}
+
+	JLOG_DEBUG("Finished sending TURN Refresh(0) for all relay entries");
+
+	return JUICE_ERR_SUCCESS;
+}
+
 JUICE_EXPORT int juice_gather_candidates(juice_agent_t *agent) {
 	if (!agent)
 		return JUICE_ERR_INVALID;


### PR DESCRIPTION
This method allows to close turn allocations setting LIFETIME to 0, as https://www.rfc-editor.org/rfc/rfc8656.html described.

In [libdatachannel ](https://github.com/paullouisageneau/libdatachannel) this method can used by `IceTransport`:
>     void IceTransport::closeTurnAllocation() {
>        PLOG_INFO << "Closing TURN allocation";
>        if (juice_close_turn_allocation(mAgent.get()) < 0) {
>            PLOG_WARN << "Failed to close TURN allocation";
>        }
>        PLOG_DEBUG << "TURN allocation closed successfully";
>     }

And this call during the `PeerConnection::closeTransports()`:

> 	if (!changeState(State::Closed))
> 		return; // already closed
>
>      if (mIceTransport)
>      {
>         PLOG_VERBOSE << "Close turn allocation if any";
>         mIceTransport->closeTurnAllocation();
>      }
>
> 	// Reset interceptor and callbacks now that state is changed
> 	setMediaHandler(nullptr);
>	resetCallbacks();