### PR TITLE
gcc 14.2.0 optimization tolerant

### DIFF
--- a/test/gathering.c
+++ b/test/gathering.c
@@ -23,8 +23,8 @@ static void sleep(unsigned int secs) { Sleep(secs * 1000); }
 #define BUFFER_SIZE 4096
 
 static juice_agent_t *agent;
-static bool success = false;
-static bool done = false;
+volatile bool success = false;
+volatile bool done = false;
 
 static void on_state_changed(juice_agent_t *agent, juice_state_t state, void *user_ptr);
 static void on_candidate(juice_agent_t *agent, const char *sdp, void *user_ptr);


### PR DESCRIPTION
when using gcc (Ubuntu 14.2.0-19ubuntu2) 14.2.0, test continued gathering candidates, ignoring 'success' variable.
 