### PR TITLE
Fix mutex handle leak when destroying connections registry

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -119,6 +119,7 @@ static void release_registry(conn_mode_entry_t *entry, conn_registry_t *registry
 			entry->registry_cleanup_func(registry);
 
 		entry->registry = NULL;
+		mutex_destroy(&registry->mutex);
 		free(registry->agents);
 		free(registry);
 		return;


### PR DESCRIPTION
`release_registry()` frees the registry without destroying the mutex initialized in `acquire_registry()`. On Windows, `mutex_t` is a kernel handle created with `CreateMutex()` (see `thread.h`), so every registry destruction leaks one handle. On POSIX platforms `pthread_mutex_destroy()` is essentially a no-op for normal mutexes, which is why this went unnoticed.

**Impact:** With ICE UDP mux (`JUICE_CONCURRENCY_MODE_MUX`), the registry is destroyed and recreated whenever the agent count drops to zero. A WHEP/WebRTC server accepting short-lived sessions therefore leaks exactly one Mutant (mutex) handle per session cycle. We observed linear handle growth (+1 per session) in a 30-minute soak test of a libdatachannel-based relay on Windows 11; handle-type diffing via `NtQuerySystemInformation` confirmed the growth is exclusively Mutant handles pointing at this call site.

**Fix:** call `mutex_destroy(&registry->mutex)` before `free(registry)`. Re-running the soak test after the fix shows a flat handle count over 90 session cycles.

This PR was prepared with AI assistance (Claude); the bug analysis and fix were verified by testing as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)