### PR TITLE
Set SOVERSION on shared library target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
 add_library(juice ${LIBJUICE_SOURCES})
-set_target_properties(juice PROPERTIES VERSION ${PROJECT_VERSION})
+set_target_properties(juice PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
 target_include_directories(juice PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)


### PR DESCRIPTION
Setting SOVERSION ensures CMake makes a proper symlink, so e.g. libjuice.so.1.7.2 will get a libjuice.so.1 symlink, with similar behaviour (and just a different extension) on macOS. Consumers of libjuice can then link against this SOVERSION instead of the full library, which means upgrading will work as long as the major version remains the same (which is expected to work - on breaking changes the major version should be upped).