### PR TITLE
Add RFC 5780 NAT behavior discovery support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ set(TESTS_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/test/stun-unhandled-no-host.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test/stun-unhandled-unhandle.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test/stun.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/rfc5780.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test/gathering.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test/connectivity.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test/turn.c

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ For a STUN/TURN server application based on libjuice, see [Violet](https://githu
 
 The library implements a simplified full ICE agent ([RFC5245](https://www.rfc-editor.org/rfc/rfc5245.html) then [RFC8445](https://www.rfc-editor.org/rfc/rfc8445.html)) featuring:
 - STUN protocol ([RFC5389](https://www.rfc-editor.org/rfc/rfc5389.html) then [RFC8489](https://www.rfc-editor.org/rfc/rfc8489.html))
+- NAT behavior discovery attributes in the STUN protocol layer ([RFC5780](https://www.rfc-editor.org/rfc/rfc5780.html)): CHANGE-REQUEST, RESPONSE-ORIGIN, OTHER-ADDRESS, RESPONSE-PORT, and PADDING
 - TURN relaying ([RFC5766](https://www.rfc-editor.org/rfc/rfc5766.html) then [RFC8656](https://www.rfc-editor.org/rfc/rfc8656.html))
 - TCP candidates ([RFC6544](https://www.rfc-editor.org/rfc/rfc6544.html))
 - ICE Consent freshness ([RFC7675](https://www.rfc-editor.org/rfc/rfc7675.html))
@@ -34,7 +35,7 @@ The limitations compared to a fully-featured ICE agent are:
 - Only one component is supported, which is sufficient for WebRTC Data Channels and multiplexed RTP+RTCP.
 - Only [RFC8828](https://www.rfc-editor.org/rfc/rfc8828) mode 2 is supported (default route + all local addresses).
 
-It also implements a lightweight STUN/TURN server ([RFC8489](https://www.rfc-editor.org/rfc/rfc8489.html) and [RFC8656](https://www.rfc-editor.org/rfc/rfc8656.html)). The server can be disabled at compile-time with the `NO_SERVER` flag.
+It also implements a lightweight STUN/TURN server ([RFC8489](https://www.rfc-editor.org/rfc/rfc8489.html) and [RFC8656](https://www.rfc-editor.org/rfc/rfc8656.html)). It adds RESPONSE-ORIGIN to Binding responses and honors RESPONSE-PORT, but as it listens on a single address it does not support NAT behavior discovery: it never advertises OTHER-ADDRESS and answers 420 to CHANGE-REQUEST, as [RFC5780](https://www.rfc-editor.org/rfc/rfc5780.html) mandates in that case. The server can be disabled at compile-time with the `NO_SERVER` flag.
 
 ## Dependencies
 

--- a/src/server.c
+++ b/src/server.c
@@ -88,6 +88,28 @@ static void delete_allocation(server_turn_alloc_t *alloc) {
 	alloc->credentials = NULL;
 }
 
+// RFC 5780: The RESPONSE-ORIGIN attribute is inserted by the server and indicates the source IP
+// address and port the response was sent from
+static void init_response_origin(juice_server_t *server) {
+	if (server->config.external_address && *server->config.external_address != '\0') {
+		char service[8];
+		snprintf(service, sizeof(service), "%hu", server->config.port);
+		int count = addr_resolve(server->config.external_address, service, SOCK_DGRAM,
+		                         server->response_origin, 2);
+		server->response_origin_count = count > 0 ? (count < 2 ? count : 2) : 0;
+		return;
+	}
+
+	// The origin is only known if the socket is bound to a specific address
+	addr_record_t record;
+	if (udp_get_bound_addr(server->sock, &record) == 0 &&
+	    !addr_is_any((struct sockaddr *)&record.addr)) {
+		addr_unmap_inet6_v4mapped((struct sockaddr *)&record.addr, &record.len);
+		server->response_origin[0] = record;
+		server->response_origin_count = 1;
+	}
+}
+
 static thread_return_t THREAD_CALL server_thread_entry(void *arg) {
 	thread_set_name_self("juice server");
 	server_run((juice_server_t *)arg);
@@ -184,6 +206,7 @@ juice_server_t *server_create(const juice_server_config_t *config) {
 
 	server->config.port = udp_get_port(server->sock);
 	server->nonce_key_timestamp = 0;
+	init_response_origin(server);
 	if (server->config.max_peers == 0)
 		server->config.max_peers = SERVER_DEFAULT_MAX_PEERS;
 
@@ -782,7 +805,7 @@ int server_dispatch_stun(juice_server_t *server, void *buf, size_t size, stun_me
 }
 
 int server_answer_stun_binding(juice_server_t *server, const uint8_t *transaction_id,
-                               const addr_record_t *src) {
+                               const addr_record_t *src, const addr_record_t *dst) {
 	JLOG_DEBUG("Answering STUN Binding request");
 
 	stun_message_t ans;
@@ -792,6 +815,13 @@ int server_answer_stun_binding(juice_server_t *server, const uint8_t *transactio
 	ans.mapped = *src;
 	memcpy(ans.transaction_id, transaction_id, STUN_TRANSACTION_ID_SIZE);
 
+	for (int i = 0; i < server->response_origin_count; ++i) {
+		if (server->response_origin[i].addr.ss_family == src->addr.ss_family) {
+			ans.response_origin = server->response_origin[i];
+			break;
+		}
+	}
+
 	char buffer[BUFFER_SIZE];
 	int size = stun_write(buffer, BUFFER_SIZE, &ans, NULL);
 	if (size <= 0) {
@@ -799,7 +829,7 @@ int server_answer_stun_binding(juice_server_t *server, const uint8_t *transactio
 		return -1;
 	}
 
-	if (server_send(server, src, buffer, size) < 0) {
+	if (server_send(server, dst, buffer, size) < 0) {
 		JLOG_WARN("STUN message send failed, errno=%d", sockerrno);
 		return -1;
 	}
@@ -825,6 +855,23 @@ int server_answer_stun_error(juice_server_t *server, const uint8_t *transaction_
 	return server_stun_send(server, src, &ans, credentials ? credentials->password : NULL);
 }
 
+static int server_answer_stun_unknown_attribute(juice_server_t *server, const stun_message_t *msg,
+                                                const addr_record_t *src, uint16_t attr_type) {
+	JLOG_DEBUG("Answering STUN error response with code 420 for attribute 0x%X",
+	           (unsigned int)attr_type);
+
+	stun_message_t ans;
+	memset(&ans, 0, sizeof(ans));
+	ans.msg_class = STUN_CLASS_RESP_ERROR;
+	ans.msg_method = msg->msg_method;
+	ans.error_code = 420; // Unknown Attribute
+	ans.unknown_attributes[0] = attr_type;
+	ans.unknown_attributes_count = 1;
+	memcpy(ans.transaction_id, msg->transaction_id, STUN_TRANSACTION_ID_SIZE);
+
+	return server_stun_send(server, src, &ans, NULL);
+}
+
 int server_process_stun_binding(juice_server_t *server, const stun_message_t *msg,
                                 const addr_record_t *src) {
 	if (JLOG_INFO_ENABLED) {
@@ -833,7 +880,32 @@ int server_process_stun_binding(juice_server_t *server, const stun_message_t *ms
 		JLOG_INFO("Got STUN binding from client %s", src_str);
 	}
 
-	return server_answer_stun_binding(server, msg->transaction_id, src);
+	// RFC 5780: The server MUST NOT process a request containing a RESPONSE-PORT and a PADDING
+	// attribute
+	if (msg->has_response_port && msg->padding) {
+		JLOG_DEBUG("Rejecting STUN Binding request with both RESPONSE-PORT and PADDING");
+		return server_answer_stun_error(server, msg->transaction_id, src, msg->msg_method,
+		                                400, // Bad Request
+		                                NULL);
+	}
+
+	// RFC 5780: If a server cannot allocate the same ports on two different IP address, then it
+	// MUST NOT include an OTHER-ADDRESS attribute in any Response and MUST respond with a 420
+	// (Unknown Attribute) to any Request with a CHANGE-REQUEST attribute.
+	// An empty CHANGE-REQUEST is accepted, as some clients add one to plain Binding requests.
+	if (msg->change_ip || msg->change_port) {
+		JLOG_DEBUG("Rejecting STUN Binding request with CHANGE-REQUEST, the server has a single "
+		           "address");
+		return server_answer_stun_unknown_attribute(server, msg, src, STUN_ATTR_CHANGE_REQUEST);
+	}
+
+	addr_record_t dst = *src;
+	if (msg->has_response_port) {
+		addr_set_port((struct sockaddr *)&dst.addr, msg->response_port);
+		JLOG_DEBUG("Sending STUN Binding response to response port %hu", msg->response_port);
+	}
+
+	return server_answer_stun_binding(server, msg->transaction_id, src, &dst);
 }
 
 int server_process_turn_allocate(juice_server_t *server, const stun_message_t *msg,

--- a/src/server.h
+++ b/src/server.h
@@ -60,6 +60,8 @@ typedef struct juice_server {
 	juice_credentials_list_t *credentials; // Credentials are stored in this list
 	uint8_t nonce_key[SERVER_NONCE_KEY_SIZE];
 	timestamp_t nonce_key_timestamp;
+	addr_record_t response_origin[2]; // one per address family
+	int response_origin_count;
 	socket_t sock;
 	thread_t thread;
 	mutex_t mutex;
@@ -98,7 +100,7 @@ void server_prepare_credentials(juice_server_t *server, const addr_record_t *src
 int server_dispatch_stun(juice_server_t *server, void *buf, size_t size, stun_message_t *msg,
                          const addr_record_t *src);
 int server_answer_stun_binding(juice_server_t *server, const uint8_t *transaction_id,
-                               const addr_record_t *src);
+                               const addr_record_t *src, const addr_record_t *dst);
 int server_answer_stun_error(juice_server_t *server, const uint8_t *transaction_id,
                              const addr_record_t *src, stun_method_t method, unsigned int code,
                              const juice_server_credentials_t *credentials);

--- a/src/stun.c
+++ b/src/stun.c
@@ -130,6 +130,22 @@ int stun_write(void *buf, size_t size, const stun_message_t *msg, const char *pa
 			goto overflow;
 		pos += len;
 	}
+	if (msg->unknown_attributes_count) {
+		JLOG_VERBOSE("Writing unknown attributes");
+		size_t count = msg->unknown_attributes_count;
+		if (count > STUN_MAX_UNKNOWN_ATTRIBUTES)
+			count = STUN_MAX_UNKNOWN_ATTRIBUTES;
+
+		uint16_t attributes[STUN_MAX_UNKNOWN_ATTRIBUTES];
+		for (size_t i = 0; i < count; ++i)
+			attributes[i] = htons(msg->unknown_attributes[i]);
+
+		len = stun_write_attr(pos, end - pos, STUN_ATTR_UNKNOWN_ATTRIBUTES, attributes,
+		                      count * sizeof(uint16_t));
+		if (len <= 0)
+			goto overflow;
+		pos += len;
+	}
 	if (msg->mapped.len) {
 		JLOG_VERBOSE("Writing XOR mapped address");
 		uint8_t value[32];
@@ -139,6 +155,60 @@ int stun_write(void *buf, size_t size, const stun_message_t *msg, const char *pa
 		    value, 32, (const struct sockaddr *)&msg->mapped.addr, msg->mapped.len, mask);
 		if (value_len > 0) {
 			len = stun_write_attr(pos, end - pos, STUN_ATTR_XOR_MAPPED_ADDRESS, value, value_len);
+			if (len <= 0)
+				goto overflow;
+			pos += len;
+		}
+	}
+	if (msg->has_change_request) {
+		JLOG_VERBOSE("Writing change request");
+		uint32_t change_request = htonl(msg->change_request);
+		len = stun_write_attr(pos, end - pos, STUN_ATTR_CHANGE_REQUEST, &change_request, 4);
+		if (len <= 0)
+			goto overflow;
+		pos += len;
+	}
+	if (msg->has_response_port) {
+		JLOG_VERBOSE("Writing response port");
+		// RFC 5780: The RESPONSE-PORT attribute is a 16-bit unsigned integer in network byte order
+		// followed by 2 bytes of padding
+		uint16_t response_port = htons(msg->response_port);
+		len = stun_write_attr(pos, end - pos, STUN_ATTR_RESPONSE_PORT, &response_port,
+		                      sizeof(response_port));
+		if (len <= 0)
+			goto overflow;
+		pos += len;
+	}
+	if (msg->padding && msg->padding_size) {
+		JLOG_VERBOSE("Writing padding");
+		len = stun_write_attr(pos, end - pos, STUN_ATTR_PADDING, msg->padding, msg->padding_size);
+		if (len <= 0)
+			goto overflow;
+		pos += len;
+	}
+	if (msg->response_origin.len) {
+		JLOG_VERBOSE("Writing response origin");
+		uint8_t value[32];
+		uint8_t zero_mask[16] = {0};
+		int value_len = stun_write_value_mapped_address(
+		    value, 32, (const struct sockaddr *)&msg->response_origin.addr, msg->response_origin.len,
+		    zero_mask);
+		if (value_len > 0) {
+			len = stun_write_attr(pos, end - pos, STUN_ATTR_RESPONSE_ORIGIN, value, value_len);
+			if (len <= 0)
+				goto overflow;
+			pos += len;
+		}
+	}
+	if (msg->other_address.len) {
+		JLOG_VERBOSE("Writing other address");
+		uint8_t value[32];
+		uint8_t zero_mask[16] = {0};
+		int value_len = stun_write_value_mapped_address(
+		    value, 32, (const struct sockaddr *)&msg->other_address.addr, msg->other_address.len,
+		    zero_mask);
+		if (value_len > 0) {
+			len = stun_write_attr(pos, end - pos, STUN_ATTR_OTHER_ADDRESS, value, value_len);
 			if (len <= 0)
 				goto overflow;
 			pos += len;
@@ -659,6 +729,51 @@ int stun_read_attr(const void *data, size_t size, stun_message_t *msg, uint8_t *
 			return -1;
 		break;
 	}
+	case STUN_ATTR_CHANGE_REQUEST: {
+		JLOG_VERBOSE("Reading change request");
+		if (length != 4) {
+			JLOG_DEBUG("STUN change request length invalid, length=%zu", length);
+			return -1;
+		}
+		msg->change_request = ntohl(*((uint32_t *)attr->value));
+		msg->has_change_request = true;
+		msg->change_ip = (msg->change_request & STUN_CHANGE_REQUEST_IP) != 0;
+		msg->change_port = (msg->change_request & STUN_CHANGE_REQUEST_PORT) != 0;
+		break;
+	}
+	case STUN_ATTR_RESPONSE_PORT: {
+		JLOG_VERBOSE("Reading response port");
+		// The value is a 16-bit port followed by 2 bytes of padding, which implementations either
+		// account for in the attribute length or leave to the regular attribute padding
+		if (length != 2 && length != 4) {
+			JLOG_DEBUG("STUN response port length invalid, length=%zu", length);
+			return -1;
+		}
+		msg->response_port = ntohs(*((uint16_t *)attr->value));
+		msg->has_response_port = true;
+		break;
+	}
+	case STUN_ATTR_PADDING: {
+		JLOG_VERBOSE("Reading padding");
+		msg->padding = (const char *)attr->value;
+		msg->padding_size = length;
+		break;
+	}
+	case STUN_ATTR_RESPONSE_ORIGIN: {
+		JLOG_VERBOSE("Reading response origin");
+		uint8_t zero_mask[16] = {0};
+		if (stun_read_value_mapped_address(attr->value, length, &msg->response_origin, zero_mask) <
+		    0)
+			return -1;
+		break;
+	}
+	case STUN_ATTR_OTHER_ADDRESS: {
+		JLOG_VERBOSE("Reading other address");
+		uint8_t zero_mask[16] = {0};
+		if (stun_read_value_mapped_address(attr->value, length, &msg->other_address, zero_mask) < 0)
+			return -1;
+		break;
+	}
 	case STUN_ATTR_ALTERNATE_SERVER: {
 		JLOG_VERBOSE("Reading alternate server");
 		uint8_t zero_mask[16] = {0};
@@ -696,9 +811,12 @@ int stun_read_attr(const void *data, size_t size, stun_message_t *msg, uint8_t *
 	case STUN_ATTR_UNKNOWN_ATTRIBUTES: {
 		JLOG_VERBOSE("Reading STUN unknown attributes");
 		const uint16_t *attributes = (const uint16_t *)attr->value;
-		for (int i = 0; i < (int)ntohs(attr->length) / 2; ++i) {
+		msg->unknown_attributes_count = 0;
+		for (size_t i = 0; i < length / sizeof(uint16_t); ++i) {
 			stun_attr_type_t type = (stun_attr_type_t)ntohs(attributes[i]);
 			JLOG_INFO("Got unknown attribute response for attribute 0x%X", (unsigned int)type);
+			if (msg->unknown_attributes_count < STUN_MAX_UNKNOWN_ATTRIBUTES)
+				msg->unknown_attributes[msg->unknown_attributes_count++] = (uint16_t)type;
 		}
 		break;
 	}

--- a/src/stun.h
+++ b/src/stun.h
@@ -102,6 +102,7 @@ struct stun_attr {
 typedef enum stun_attr_type {
 	// Comprehension-required
 	STUN_ATTR_MAPPED_ADDRESS = 0x0001,
+	STUN_ATTR_CHANGE_REQUEST = 0x0003,
 	STUN_ATTR_USERNAME = 0x0006,
 	STUN_ATTR_MESSAGE_INTEGRITY = 0x0008,
 	STUN_ATTR_ERROR_CODE = 0x0009,
@@ -114,6 +115,8 @@ typedef enum stun_attr_type {
 	STUN_ATTR_XOR_MAPPED_ADDRESS = 0x0020,
 	STUN_ATTR_PRIORITY = 0x0024,
 	STUN_ATTR_USE_CANDIDATE = 0x0025,
+	STUN_ATTR_PADDING = 0x0026,
+	STUN_ATTR_RESPONSE_PORT = 0x0027,
 
 	// Comprehension-optional
 	STUN_ATTR_PASSWORD_ALGORITHMS = 0x8002,
@@ -123,6 +126,8 @@ typedef enum stun_attr_type {
 	STUN_ATTR_FINGERPRINT = 0x8028,
 	STUN_ATTR_ICE_CONTROLLED = 0x8029,
 	STUN_ATTR_ICE_CONTROLLING = 0x802A,
+	STUN_ATTR_RESPONSE_ORIGIN = 0x802B,
+	STUN_ATTR_OTHER_ADDRESS = 0x802C,
 
 	// Attributes for TURN
 	// See https://www.rfc-editor.org/rfc/rfc8656.html#section-18
@@ -300,6 +305,13 @@ typedef enum stun_password_algorithm {
 // RFC 5766: When forming a CreatePermission request, the client MUST include at least one XOR-PEER-ADDRESS attribute, and MAY include more than one such attribute.
 #define STUN_MAX_PEER_ADDRESSES 8
 
+#define STUN_MAX_UNKNOWN_ATTRIBUTES 8
+
+// RFC 5780: The CHANGE-REQUEST attribute contains two flags to control the IP address and port that
+// the server uses to send the response
+#define STUN_CHANGE_REQUEST_IP 0x04
+#define STUN_CHANGE_REQUEST_PORT 0x02
+
 typedef struct stun_credentials {
 	char username[STUN_MAX_USERNAME_LEN];
 	char realm[STUN_MAX_REALM_LEN];
@@ -320,7 +332,21 @@ typedef struct stun_message {
 	uint64_t ice_controlling;
 	uint64_t ice_controlled;
 	bool use_candidate;
+	uint16_t unknown_attributes[STUN_MAX_UNKNOWN_ATTRIBUTES];
+	size_t unknown_attributes_count;
 	addr_record_t mapped;
+
+	// RFC 5780
+	uint32_t change_request;
+	bool has_change_request;
+	bool change_ip;
+	bool change_port;
+	uint16_t response_port;
+	bool has_response_port;
+	const char *padding;
+	size_t padding_size;
+	addr_record_t response_origin;
+	addr_record_t other_address;
 
 	stun_credentials_t credentials;
 

--- a/test/main.c
+++ b/test/main.c
@@ -9,10 +9,15 @@
 #include "juice/juice.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 
 int test_crc32(void);
 int test_base64(void);
 int test_stun(void);
+int test_rfc5780(void);
+#ifndef _WIN32
+int test_rfc5780_public(void);
+#endif
 int test_connectivity(void);
 int test_thread(void);
 int test_mux(void);
@@ -53,6 +58,22 @@ int main(int argc, char **argv) {
 		fprintf(stderr, "STUN parsing implementation test failed\n");
 		return -3;
 	}
+
+	printf("\nRunning RFC 5780 NAT behavior discovery test...\n");
+	if (test_rfc5780()) {
+		fprintf(stderr, "RFC 5780 NAT behavior discovery test failed\n");
+		return -3;
+	}
+
+#ifndef _WIN32
+	if (getenv("JUICE_RUN_PUBLIC_STUN_TESTS")) {
+		printf("\nRunning RFC 5780 public STUN server test...\n");
+		if (test_rfc5780_public()) {
+			fprintf(stderr, "RFC 5780 public STUN server test failed\n");
+			return -3;
+		}
+	}
+#endif
 
 	printf("\nRunning candidates gathering test...\n");
 	if (test_gathering()) {

--- a/test/rfc5780.c
+++ b/test/rfc5780.c
@@ -1,0 +1,515 @@
+/**
+ * Copyright (c) 2026 Daniel Golle
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "juice/juice.h"
+#include "stun.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+typedef SOCKET test_socket_t;
+#define TEST_INVALID_SOCKET INVALID_SOCKET
+#define test_closesocket closesocket
+#else
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+typedef int test_socket_t;
+#define TEST_INVALID_SOCKET (-1)
+#define test_closesocket close
+#endif
+
+#define BUFFER_SIZE 4096
+#define LOCALHOST 0x7F000001 // 127.0.0.1
+
+static const uint8_t transaction_id[STUN_TRANSACTION_ID_SIZE] = "0123456789A";
+
+static void set_ipv4(addr_record_t *record, uint32_t address, uint16_t port) {
+	memset(record, 0, sizeof(*record));
+	struct sockaddr_in *sin = (struct sockaddr_in *)&record->addr;
+	sin->sin_family = AF_INET;
+	sin->sin_port = htons(port);
+	sin->sin_addr.s_addr = htonl(address);
+	record->len = sizeof(*sin);
+	record->socktype = SOCK_DGRAM;
+}
+
+static bool is_ipv4(const addr_record_t *record, uint32_t address, uint16_t port) {
+	if (record->addr.ss_family != AF_INET)
+		return false;
+
+	const struct sockaddr_in *sin = (const struct sockaddr_in *)&record->addr;
+	return sin->sin_port == htons(port) && sin->sin_addr.s_addr == htonl(address);
+}
+
+static void init_binding_request(stun_message_t *msg) {
+	memset(msg, 0, sizeof(*msg));
+	msg->msg_class = STUN_CLASS_REQUEST;
+	msg->msg_method = STUN_METHOD_BINDING;
+	memcpy(msg->transaction_id, transaction_id, STUN_TRANSACTION_ID_SIZE);
+}
+
+static const uint8_t *find_attr(const uint8_t *buffer, int size, uint16_t type) {
+	const uint8_t *pos = buffer + sizeof(struct stun_header);
+	const uint8_t *end = buffer + size;
+	while (pos + sizeof(struct stun_attr) <= end) {
+		size_t length = (size_t)(pos[2] << 8 | pos[3]);
+		if ((uint16_t)(pos[0] << 8 | pos[1]) == type)
+			return pos;
+
+		pos += sizeof(struct stun_attr) + ((length + 3) & ~(size_t)3);
+	}
+	return NULL;
+}
+
+static int test_rfc5780_request_attributes(void) {
+	char padding[64];
+	memset(padding, 0, sizeof(padding));
+
+	stun_message_t msg;
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_class = STUN_CLASS_REQUEST;
+	msg.msg_method = STUN_METHOD_BINDING;
+	memcpy(msg.transaction_id, transaction_id, STUN_TRANSACTION_ID_SIZE);
+	msg.change_request = STUN_CHANGE_REQUEST_IP | STUN_CHANGE_REQUEST_PORT;
+	msg.has_change_request = true;
+	msg.response_port = 3479;
+	msg.has_response_port = true;
+	msg.padding = padding;
+	msg.padding_size = sizeof(padding);
+
+	uint8_t buffer[BUFFER_SIZE];
+	int size = _juice_stun_write(buffer, BUFFER_SIZE, &msg, NULL);
+	if (size <= 0) {
+		printf("Writing RFC 5780 request attributes failed\n");
+		return -1;
+	}
+
+	stun_message_t parsed;
+	memset(&parsed, 0, sizeof(parsed));
+	if (_juice_stun_read(buffer, size, &parsed) <= 0) {
+		printf("Reading RFC 5780 request attributes failed\n");
+		return -1;
+	}
+
+	if (!parsed.has_change_request || !parsed.change_ip || !parsed.change_port) {
+		printf("CHANGE-REQUEST is incorrect\n");
+		return -1;
+	}
+	if (!parsed.has_response_port || parsed.response_port != 3479) {
+		printf("RESPONSE-PORT is incorrect\n");
+		return -1;
+	}
+	if (parsed.padding_size != sizeof(padding)) {
+		printf("PADDING is incorrect\n");
+		return -1;
+	}
+
+	const uint8_t *attr = find_attr(buffer, size, STUN_ATTR_RESPONSE_PORT);
+	if (!attr || attr[2] != 0 || attr[3] != 2) {
+		printf("RESPONSE-PORT attribute length is incorrect\n");
+		return -1;
+	}
+
+	// Some implementations count the 2 padding bytes in the attribute length instead
+	uint8_t raw[BUFFER_SIZE];
+	memcpy(raw, buffer, sizeof(struct stun_header)); // same header, with a single attribute
+	raw[2] = 0;
+	raw[3] = sizeof(struct stun_attr) + 4;
+	uint8_t *raw_attr = raw + sizeof(struct stun_header);
+	raw_attr[0] = STUN_ATTR_RESPONSE_PORT >> 8;
+	raw_attr[1] = STUN_ATTR_RESPONSE_PORT & 0xFF;
+	raw_attr[2] = 0;
+	raw_attr[3] = 4;
+	raw_attr[4] = 3479 >> 8;
+	raw_attr[5] = 3479 & 0xFF;
+	raw_attr[6] = 0;
+	raw_attr[7] = 0;
+
+	size = (int)(sizeof(struct stun_header) + sizeof(struct stun_attr) + 4);
+	memset(&parsed, 0, sizeof(parsed));
+	if (_juice_stun_read(raw, size, &parsed) <= 0) {
+		printf("Reading a 4-byte long RESPONSE-PORT failed\n");
+		return -1;
+	}
+	if (!parsed.has_response_port || parsed.response_port != 3479) {
+		printf("RESPONSE-PORT read from a 4-byte long attribute is incorrect\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+static int test_rfc5780_response_attributes(void) {
+	stun_message_t msg;
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_class = STUN_CLASS_RESP_SUCCESS;
+	msg.msg_method = STUN_METHOD_BINDING;
+	memcpy(msg.transaction_id, transaction_id, STUN_TRANSACTION_ID_SIZE);
+	set_ipv4(&msg.mapped, 0xC0000201, 12345);        // 192.0.2.1
+	set_ipv4(&msg.response_origin, 0xC0000202, 3478); // 192.0.2.2
+	set_ipv4(&msg.other_address, 0xC0000203, 3479);   // 192.0.2.3
+
+	uint8_t buffer[BUFFER_SIZE];
+	int size = _juice_stun_write(buffer, BUFFER_SIZE, &msg, NULL);
+	if (size <= 0) {
+		printf("Writing RFC 5780 response attributes failed\n");
+		return -1;
+	}
+
+	stun_message_t parsed;
+	memset(&parsed, 0, sizeof(parsed));
+	if (_juice_stun_read(buffer, size, &parsed) <= 0) {
+		printf("Reading RFC 5780 response attributes failed\n");
+		return -1;
+	}
+
+	if (!is_ipv4(&parsed.mapped, 0xC0000201, 12345)) {
+		printf("XOR-MAPPED-ADDRESS is incorrect\n");
+		return -1;
+	}
+	if (!is_ipv4(&parsed.response_origin, 0xC0000202, 3478)) {
+		printf("RESPONSE-ORIGIN is incorrect\n");
+		return -1;
+	}
+	if (!is_ipv4(&parsed.other_address, 0xC0000203, 3479)) {
+		printf("OTHER-ADDRESS is incorrect\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+static int test_rfc5780_unknown_attributes(void) {
+	stun_message_t msg;
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_class = STUN_CLASS_RESP_ERROR;
+	msg.msg_method = STUN_METHOD_BINDING;
+	memcpy(msg.transaction_id, transaction_id, STUN_TRANSACTION_ID_SIZE);
+	msg.error_code = 420;
+	msg.unknown_attributes[0] = STUN_ATTR_CHANGE_REQUEST;
+	msg.unknown_attributes_count = 1;
+
+	uint8_t buffer[BUFFER_SIZE];
+	int size = _juice_stun_write(buffer, BUFFER_SIZE, &msg, NULL);
+	if (size <= 0) {
+		printf("Writing UNKNOWN-ATTRIBUTES failed\n");
+		return -1;
+	}
+
+	stun_message_t parsed;
+	memset(&parsed, 0, sizeof(parsed));
+	if (_juice_stun_read(buffer, size, &parsed) <= 0) {
+		printf("Reading UNKNOWN-ATTRIBUTES failed\n");
+		return -1;
+	}
+
+	if (parsed.error_code != 420) {
+		printf("Error code is incorrect\n");
+		return -1;
+	}
+	if (parsed.unknown_attributes_count != 1 ||
+	    parsed.unknown_attributes[0] != STUN_ATTR_CHANGE_REQUEST) {
+		printf("UNKNOWN-ATTRIBUTES is incorrect\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+#ifndef NO_SERVER
+
+static test_socket_t create_test_socket(uint16_t *port) {
+	test_socket_t sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+	if (sock == TEST_INVALID_SOCKET)
+		return TEST_INVALID_SOCKET;
+
+	struct sockaddr_in sin;
+	memset(&sin, 0, sizeof(sin));
+	sin.sin_family = AF_INET;
+	sin.sin_addr.s_addr = htonl(LOCALHOST);
+	if (bind(sock, (const struct sockaddr *)&sin, sizeof(sin))) {
+		test_closesocket(sock);
+		return TEST_INVALID_SOCKET;
+	}
+
+	socklen_t sinlen = sizeof(sin);
+	if (getsockname(sock, (struct sockaddr *)&sin, &sinlen)) {
+		test_closesocket(sock);
+		return TEST_INVALID_SOCKET;
+	}
+	*port = ntohs(sin.sin_port);
+
+#ifdef _WIN32
+	DWORD timeout = 1000;
+#else
+	struct timeval timeout = {1, 0};
+#endif
+	setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char *)&timeout, sizeof(timeout));
+	return sock;
+}
+
+static int send_stun(test_socket_t sock, uint16_t port, const stun_message_t *msg) {
+	char buffer[BUFFER_SIZE];
+	int size = _juice_stun_write(buffer, BUFFER_SIZE, msg, NULL);
+	if (size <= 0)
+		return -1;
+
+	struct sockaddr_in sin;
+	memset(&sin, 0, sizeof(sin));
+	sin.sin_family = AF_INET;
+	sin.sin_port = htons(port);
+	sin.sin_addr.s_addr = htonl(LOCALHOST);
+	if (sendto(sock, buffer, size, 0, (const struct sockaddr *)&sin, sizeof(sin)) != size)
+		return -1;
+
+	return 0;
+}
+
+static int recv_stun(test_socket_t sock, stun_message_t *msg) {
+	char buffer[BUFFER_SIZE];
+	int len = (int)recvfrom(sock, buffer, BUFFER_SIZE, 0, NULL, NULL);
+	if (len <= 0)
+		return -1;
+
+	memset(msg, 0, sizeof(*msg));
+	if (_juice_stun_read(buffer, len, msg) <= 0)
+		return -1;
+
+	if (memcmp(msg->transaction_id, transaction_id, STUN_TRANSACTION_ID_SIZE) != 0)
+		return -1;
+
+	return 0;
+}
+
+static int test_rfc5780_server_behavior(uint16_t server_port) {
+	uint16_t port, alternate_port;
+	test_socket_t sock = create_test_socket(&port);
+	test_socket_t alternate_sock = create_test_socket(&alternate_port);
+	if (sock == TEST_INVALID_SOCKET || alternate_sock == TEST_INVALID_SOCKET) {
+		printf("Test socket creation failed\n");
+		goto error;
+	}
+
+	// A Binding request must be answered with RESPONSE-ORIGIN and without OTHER-ADDRESS
+	stun_message_t msg;
+	stun_message_t ans;
+	init_binding_request(&msg);
+	if (send_stun(sock, server_port, &msg) || recv_stun(sock, &ans)) {
+		printf("No answer to Binding request\n");
+		goto error;
+	}
+	if (ans.msg_class != STUN_CLASS_RESP_SUCCESS || !is_ipv4(&ans.mapped, LOCALHOST, port)) {
+		printf("Binding response is incorrect\n");
+		goto error;
+	}
+	if (!is_ipv4(&ans.response_origin, LOCALHOST, server_port)) {
+		printf("RESPONSE-ORIGIN is missing or incorrect\n");
+		goto error;
+	}
+	if (ans.other_address.len) {
+		printf("OTHER-ADDRESS must not be advertised by a server with a single address\n");
+		goto error;
+	}
+
+	// An empty CHANGE-REQUEST must not be rejected
+	init_binding_request(&msg);
+	msg.has_change_request = true;
+	if (send_stun(sock, server_port, &msg) || recv_stun(sock, &ans)) {
+		printf("No answer to Binding request with an empty CHANGE-REQUEST\n");
+		goto error;
+	}
+	if (ans.msg_class != STUN_CLASS_RESP_SUCCESS) {
+		printf("Binding request with an empty CHANGE-REQUEST was rejected\n");
+		goto error;
+	}
+
+	// CHANGE-REQUEST must be answered with 420 as the server has a single address
+	init_binding_request(&msg);
+	msg.has_change_request = true;
+	msg.change_request = STUN_CHANGE_REQUEST_IP | STUN_CHANGE_REQUEST_PORT;
+	if (send_stun(sock, server_port, &msg) || recv_stun(sock, &ans)) {
+		printf("No answer to Binding request with CHANGE-REQUEST\n");
+		goto error;
+	}
+	if (ans.msg_class != STUN_CLASS_RESP_ERROR || ans.error_code != 420) {
+		printf("Binding request with CHANGE-REQUEST was not answered with 420\n");
+		goto error;
+	}
+	if (ans.unknown_attributes_count != 1 ||
+	    ans.unknown_attributes[0] != STUN_ATTR_CHANGE_REQUEST) {
+		printf("420 answer does not list CHANGE-REQUEST in UNKNOWN-ATTRIBUTES\n");
+		goto error;
+	}
+
+	// RESPONSE-PORT must redirect the response to the requested port
+	init_binding_request(&msg);
+	msg.has_response_port = true;
+	msg.response_port = alternate_port;
+	if (send_stun(sock, server_port, &msg) || recv_stun(alternate_sock, &ans)) {
+		printf("No answer on the port requested with RESPONSE-PORT\n");
+		goto error;
+	}
+	if (ans.msg_class != STUN_CLASS_RESP_SUCCESS || !is_ipv4(&ans.mapped, LOCALHOST, port)) {
+		printf("Binding response on the requested port is incorrect\n");
+		goto error;
+	}
+
+	// RESPONSE-PORT together with PADDING must be rejected
+	char padding[64];
+	memset(padding, 0, sizeof(padding));
+	init_binding_request(&msg);
+	msg.has_response_port = true;
+	msg.response_port = alternate_port;
+	msg.padding = padding;
+	msg.padding_size = sizeof(padding);
+	if (send_stun(sock, server_port, &msg) || recv_stun(sock, &ans)) {
+		printf("No answer to Binding request with RESPONSE-PORT and PADDING\n");
+		goto error;
+	}
+	if (ans.msg_class != STUN_CLASS_RESP_ERROR || ans.error_code != 400) {
+		printf("Binding request with RESPONSE-PORT and PADDING was not rejected\n");
+		goto error;
+	}
+
+	test_closesocket(sock);
+	test_closesocket(alternate_sock);
+	return 0;
+
+error:
+	if (sock != TEST_INVALID_SOCKET)
+		test_closesocket(sock);
+	if (alternate_sock != TEST_INVALID_SOCKET)
+		test_closesocket(alternate_sock);
+
+	return -1;
+}
+
+static int test_rfc5780_server(void) {
+	juice_server_config_t config;
+	memset(&config, 0, sizeof(config));
+	config.bind_address = "127.0.0.1";
+
+	juice_server_t *server = juice_server_create(&config);
+	if (!server) {
+		printf("Server creation failed\n");
+		return -1;
+	}
+
+	int ret = test_rfc5780_server_behavior(juice_server_get_port(server));
+	juice_server_destroy(server);
+	return ret;
+}
+
+#endif // ifndef NO_SERVER
+
+int test_rfc5780(void) {
+	if (test_rfc5780_request_attributes())
+		return -1;
+
+	if (test_rfc5780_response_attributes())
+		return -1;
+
+	if (test_rfc5780_unknown_attributes())
+		return -1;
+
+#ifndef NO_SERVER
+	if (test_rfc5780_server())
+		return -1;
+#endif
+
+	printf("Success\n");
+	return 0;
+}
+
+#ifndef _WIN32
+
+// Opt-in check against public STUN servers, enabled with JUICE_RUN_PUBLIC_STUN_TESTS
+static int probe_public_server(const char *host, const char *service) {
+	struct addrinfo hints;
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_UNSPEC;
+	hints.ai_socktype = SOCK_DGRAM;
+	hints.ai_protocol = IPPROTO_UDP;
+
+	struct addrinfo *res = NULL;
+	if (getaddrinfo(host, service, &hints, &res)) {
+		printf("Address resolution failed for %s:%s\n", host, service);
+		return -1;
+	}
+
+	int ret = -1;
+	int sock = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+	if (sock < 0) {
+		printf("Socket creation failed for %s:%s\n", host, service);
+		goto finish;
+	}
+
+	struct timeval timeout = {2, 0};
+	setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+
+	stun_message_t msg;
+	init_binding_request(&msg);
+
+	char buffer[BUFFER_SIZE];
+	int size = _juice_stun_write(buffer, BUFFER_SIZE, &msg, NULL);
+	if (size <= 0 || sendto(sock, buffer, size, 0, res->ai_addr, res->ai_addrlen) != size) {
+		printf("Sending to %s:%s failed\n", host, service);
+		goto finish;
+	}
+
+	int len = (int)recvfrom(sock, buffer, BUFFER_SIZE, 0, NULL, NULL);
+	if (len <= 0) {
+		printf("No answer from %s:%s\n", host, service);
+		goto finish;
+	}
+
+	stun_message_t ans;
+	memset(&ans, 0, sizeof(ans));
+	if (_juice_stun_read(buffer, len, &ans) <= 0) {
+		printf("Reading the answer from %s:%s failed\n", host, service);
+		goto finish;
+	}
+
+	printf("%s:%s answered with response origin=%s and other address=%s\n", host, service,
+	       ans.response_origin.len ? "yes" : "no", ans.other_address.len ? "yes" : "no");
+
+	ret = ans.response_origin.len && ans.other_address.len ? 0 : -1;
+
+finish:
+	if (sock >= 0)
+		close(sock);
+	freeaddrinfo(res);
+	return ret;
+}
+
+int test_rfc5780_public(void) {
+	const char *hosts[] = {"stun.nextcloud.com", "stun.voip.blackberry.com", "stun.acronis.com"};
+
+	if (!getenv("JUICE_RUN_PUBLIC_STUN_TESTS"))
+		return 0;
+
+	for (size_t i = 0; i < sizeof(hosts) / sizeof(hosts[0]); ++i) {
+		if (probe_public_server(hosts[i], "3478") == 0) {
+			printf("Success\n");
+			return 0;
+		}
+	}
+
+	printf("No public server advertised RESPONSE-ORIGIN and OTHER-ADDRESS\n");
+	return -1;
+}
+
+#endif // ifndef _WIN32


### PR DESCRIPTION
This implements RFC 5780 at the protocol layer only, and makes the built-in server behave correctly with respect to it. It does not add NAT behavior classification to the library, which is the part that made #113 unappealing: no NAT type enumeration, no policy, no new public API. Applications that want to classify can do so on top of the attributes, against a server that actually implements behavior discovery.

Related to #69.

### STUN protocol layer

* Read and write CHANGE-REQUEST, RESPONSE-PORT, PADDING, RESPONSE-ORIGIN and OTHER-ADDRESS.
* Write UNKNOWN-ATTRIBUTES, which RFC 5389 requires for 420 error responses.
* RESPONSE-PORT is written with a value length of 2, as specified in RFC 5780 section 7.5 ("a 16-bit unsigned integer in network byte order followed by 2 bytes of padding"), and both 2 and 4 are accepted on read since implementations differ: stuntman writes 2, coturn writes 4 and accepts anything of at least 2.

### Server

The server listens on a single address, so RFC 5780 section 6 requires it to not advertise OTHER-ADDRESS and to reject CHANGE-REQUEST. Silently answering a CHANGE-REQUEST from the primary address would be worse than not parsing the attribute at all, since a client would read the answer as endpoint-independent filtering.

* A CHANGE-REQUEST asking for a different address or port is answered with 420 (Unknown Attribute), listing CHANGE-REQUEST in UNKNOWN-ATTRIBUTES. An empty CHANGE-REQUEST is answered normally, as some clients add one to plain Binding requests; coturn makes the same exception.
* OTHER-ADDRESS is never emitted. In particular `external_address` is not used for it: it is the TURN relay advertisement, not a second STUN endpoint the server answers from.
* RESPONSE-ORIGIN is added when the source address is actually known: from `external_address` when it is configured, otherwise from the bound address when it is not a wildcard. It is omitted when neither applies, and only sent when its family matches the client's. It is resolved once at server creation, so nothing is added to the request path.
* RESPONSE-PORT sends the Binding response to the requested port on the client's address.
* A request containing both RESPONSE-PORT and PADDING is rejected with 400 (Bad Request), as required.

### Tests

`test/rfc5780.c` covers the attribute round-trips and the 4-byte RESPONSE-PORT variant, then starts a server on 127.0.0.1 and checks each of the server behaviors above over raw sockets. It runs on all three CI platforms.

It also contains an opt-in check against public STUN servers, enabled with `JUICE_RUN_PUBLIC_STUN_TESTS=1`, verifying a real behavior discovery server answers with both RESPONSE-ORIGIN and OTHER-ADDRESS. It is not run by default as it depends on third-party servers.
