### PR TITLE
picohash: fix SHA-1 on big-endian targets, and endianness detection under strict C

### DIFF
--- a/src/picohash.h
+++ b/src/picohash.h
@@ -29,7 +29,7 @@
 #endif
 #else               // ! defined __LITTLE_ENDIAN__
 #include <endian.h> // machine/endian.h
-#if BYTE_ORDER == BIG_ENDIAN
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #define _PICOHASH_BIG_ENDIAN
 #endif
 #endif

--- a/src/picohash.h
+++ b/src/picohash.h
@@ -452,7 +452,7 @@ inline void _picohash_sha1_final(_picohash_sha1_ctx_t *s, void *digest)
     _picohash_sha1_add_uncounted(s, (uint8_t)(s->byteCount >> 5));
     _picohash_sha1_add_uncounted(s, (uint8_t)(s->byteCount << 3));
 
-#ifndef SHA_BIG_ENDIAN
+#ifndef _PICOHASH_BIG_ENDIAN
     { // Swap byte order back
         int i;
         for (i = 0; i < 5; i++) {


### PR DESCRIPTION
Two independent defects in the vendored `src/picohash.h`, both affecting the correctness of SHA-1 and therefore of HMAC-SHA1 and STUN MESSAGE-INTEGRITY.

### 1. SHA-1 output swap on big-endian

`_picohash_sha1_final` guards its final "swap byte order back" step with `SHA_BIG_ENDIAN`, which nothing defines. picohash detects endianness into `_PICOHASH_BIG_ENDIAN`, which is what the matching byte store in `_picohash_sha1_add_uncounted` tests. The name comes from liboauth's `src/sha1.c`, which this SHA-1 is adopted from, and where both sites agree on it.

On a big-endian target the swap runs when it must not, so every digest is emitted with each 32-bit word reversed:

```
sha1("abc") = 363e99a96a81064771253eba6cc250789dd8d09c
   expected   a9993e364706816aba3e25717850c26c9cd0d89d
```

Since `USE_NETTLE` defaults to `OFF`, picohash is the backend for any build that does not opt into Nettle, so this affects every such build on a big-endian host.

What that looks like in practice, from a juice agent on mips_24kc:

```
ice: STUN integrity check failed, password="a118ff3aec677687897d7d987395a636"
ice: STUN message verification failed
```

repeated for every connectivity check. The agent never leaves `connecting`, no candidate pair is nominated, and no session can be established. The peer's checks arrive intact; only the integrity verdict is wrong.

This defect is present upstream as well and is filed there as kazuho/picohash#13.

### 2. Endianness detection under strict C

The fallback branch tests `BYTE_ORDER == BIG_ENDIAN`. glibc exposes those names only under `__USE_MISC`, so with `-std=c99` or `-std=c11` and no `_DEFAULT_SOURCE` neither is defined, the test becomes `0 == 0`, and `_PICOHASH_BIG_ENDIAN` is defined on a little-endian host. This one is local to the vendored copy: upstream tests `__BYTE_ORDER__` against `__ORDER_BIG_ENDIAN__` here, which the compiler always defines. The second commit restores that.

Measured on x86-64, glibc, gcc 14:

| standard | this header before | upstream header |
|---|---|---|
| `-std=gnu99` | little-endian (correct) | little-endian (correct) |
| `-std=c99` | **big-endian** | little-endian (correct) |
| `-std=c11` | **big-endian** | little-endian (correct) |

### Verification

On mips_24kc, a big-endian MIPS 34Kc running OpenWrt with musl, gcc 14.4.0:

| | before | after |
|---|---|---|
| `sha1("abc")` | `363e99a9...` | `a9993e36...` (correct) |
| RFC 2202 HMAC-SHA1 case 1 | mismatch | correct |
| ICE agent state | loops in `connecting`, integrity failures | `connected`, then `completed` |
| STUN integrity failures | hundreds | 0 |

Both directions of a real session were exercised between that host and an x86-64 peer.

Little-endian behaviour is unchanged by the first commit and corrected by thesecond.